### PR TITLE
Include standard page layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *~
 *.pyc
-*.html
+./*.html
 .DS_Store
 _site

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *~
 *.pyc
-./*.html
 .DS_Store
 _site

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
+    $header$
+  </head>
+  <body>
+    $banner$
+    $if(title)$<h1>$title$</h1>$endif$
+    $body$
+    $footer$
+    $javascript$
+  </body>
+</html>


### PR DESCRIPTION
1. Add `_layouts/page.html` (which was accidentally being excluded by an overly-zealous `.gitignore`).
2. Modify `.gitignore` so that it doesn't exclude HTML files.

Note: when the build is being tested in this repo, it creates HTML files in the root directory that should _not_ be put under version control.  When it is cloned as a starting point for an actual lesson, though, the HTML files in the root directory _should_ be committed, so the safest thing is to modify `.gitignore` so as not to ignore them, and trust that whoever's working in this repo doesn't accidentally add unwanted HTML files.

Closes #5.
