### PR TITLE
Blockquote margins

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -45,7 +45,7 @@ div.chapter h2 {
 /* Block quotations. */
 blockquote {
     margin: 1em;
-    padding: 1em 1em .5em 1em;
+    padding: .7em;
     width: 90%;
 }
 
@@ -349,6 +349,11 @@ blockquote p {
     font-weight: inherit;
     line-height: inherit;
 }
+
+blockquote h2{
+   margin-top: 0px;
+}
+
 /* readability: darken the alert colour for contrast with background */
 
 .alert {


### PR DESCRIPTION
Made a change to avoid the upper margin when using `h2` within a blockquote

![blockquote](https://cloud.githubusercontent.com/assets/579329/5039479/7d0b3b0a-6c03-11e4-960a-492d92ae8d4d.png)
