### PR TITLE
Fix template layout

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,7 +13,7 @@
         <div class="span10 offset1">
           <h1 class="title">$title$</h1>
           $if(subtitle)$<h2 class="subtitle">$subtitle$</h2>$endif$
-          $body$
+$body$
         </div>
       </div>
       $footer$

--- a/_layouts/slides.html
+++ b/_layouts/slides.html
@@ -33,7 +33,7 @@
   <div class="deck-container">
 
     <!-- Begin slides. Just make elements with a class of slide. -->
-    $body$
+$body$
     <!-- End slides. -->
 
     <!-- Begin extension snippets. Add or remove as needed. -->


### PR DESCRIPTION
**Sorry to didn't notice this before.**

![swc](https://cloud.githubusercontent.com/assets/1506457/5061844/7d16c1a8-6d90-11e4-94d7-31aaf40d0d8c.jpg)

The output box should be render as

```
output
from
program
```

instead of

```
output
        from
        program
```

**Please merge as soon as possible.**
