### PR TITLE
Prereq divs

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ file, but again, we're trying to avoid those.
     ---
     Paragraph(s) of introductory material.
 
-    > ## Prerequisites {.prereq}
+    > ## Prerequisites
     >
     > What learners need to know before tackling this lesson.
 

--- a/pages/01-one.md
+++ b/pages/01-one.md
@@ -4,7 +4,7 @@ title: Lesson Title
 subtitle: Topic Title One
 minutes: 10
 ---
-> ## Learning Objectives {.objectives}
+> ## Learning Objectives
 >
 > * Learning objective 1
 > * Learning objective 2

--- a/pages/02-two.md
+++ b/pages/02-two.md
@@ -4,7 +4,7 @@ title: Lesson Title
 subtitle: Topic Title Two
 minutes: 10
 ---
-> ## Learning Objectives {.objectives}
+> ## Learning Objectives
 >
 > * Learning objective 1
 > * Learning objective 2

--- a/tools/blockquote2div.py
+++ b/tools/blockquote2div.py
@@ -8,10 +8,11 @@ Usage:
 
 A blockquote will be converted if
 
-1. it begins with a header
-2. that header has attributes
-3. those attributes contain a single class
-4. that class is one of ['objectives', 'callout', 'challenge']
+1.  it begins with a header
+2.  that
+    1.  match "Prerequisites", "Objectives" or
+    2.  has attributes containing a single class matching
+        one of ['callout', 'challenge']
 
 For example, this is a valid blockquote:
 
@@ -36,12 +37,13 @@ import pandocfilters as pf
 
 # These are classes that, if set on the title of a blockquote, will
 # trigger the blockquote to be converted to a div.
-special_classes = ['objectives', 'callout', 'challenge']
+SPECIAL_CLASSES = ['callout', 'challenge']
 
 # These are titles of blockquotes that will cause the blockquote to
 # be converted into a div. They are 'title': 'class' pairs, where the
 # 'title' will create a blockquote with the corresponding 'class'.
-special_titles = {'prerequisites': 'prereq'}
+SPECIAL_TITLES = {'prerequisites': 'prereq',
+                  'learning objectives': 'objectives'}
 
 
 def find_header(blockquote):
@@ -88,11 +90,11 @@ def blockquote2div(key, value, format, meta):
         id, classes, kvs = attr
 
         ltitle = pf.stringify(inlines).lower()
-        if ltitle in special_titles:
-            classes.append(special_titles[ltitle])
+        if ltitle in SPECIAL_TITLES:
+            classes.append(SPECIAL_TITLES[ltitle])
             return pf.Div(attr, blockquote)
 
-        elif len(classes) == 1 and classes[0] in special_classes:
+        elif len(classes) == 1 and classes[0] in SPECIAL_CLASSES:
             remove_attributes(blockquote)
             # a blockquote is just a list of blocks, so it can be
             # passed directly to Div, which expects Div(attr, blocks)

--- a/tools/blockquote2div.py
+++ b/tools/blockquote2div.py
@@ -9,10 +9,10 @@ Usage:
 A blockquote will be converted if
 
 1.  it begins with a header
-2.  that
-    1.  match "Prerequisites", "Objectives" or
+2.  that either
+    1.  matches "Prerequisites", "Objectives", "Callout" or "Challenge" OR
     2.  has attributes containing a single class matching
-        one of ['callout', 'challenge']
+        one of ['prereq', 'objectives', 'callout', 'challenge']
 
 For example, this is a valid blockquote:
 
@@ -26,6 +26,18 @@ and it will be converted into this markdown:
     Let's do something.
     </div>
 
+This is also a valid blockquote:
+
+    > ## Prerequisites
+    > Breakfast!
+
+and it will be converted into this markdown:
+
+    <div class='prereq'>
+    ## Prerequisites
+    Breakfast!
+    </div>
+
 
 For debugging purposes you may find it useful to test the filter
 like this:
@@ -37,13 +49,16 @@ import pandocfilters as pf
 
 # These are classes that, if set on the title of a blockquote, will
 # trigger the blockquote to be converted to a div.
-SPECIAL_CLASSES = ['callout', 'challenge']
+SPECIAL_CLASSES = ['callout', 'challenge', 'prereq', 'objectives']
 
 # These are titles of blockquotes that will cause the blockquote to
 # be converted into a div. They are 'title': 'class' pairs, where the
 # 'title' will create a blockquote with the corresponding 'class'.
 SPECIAL_TITLES = {'prerequisites': 'prereq',
-                  'learning objectives': 'objectives'}
+                  'learning objectives': 'objectives',
+                  'objectives': 'objectives',
+                  'challenge': 'challenge',
+                  'callout': 'callout'}
 
 
 def find_header(blockquote):


### PR DESCRIPTION
Addresses #25. Also blocking #22.

Previously, Div creation was triggered by a Blockquote that began with a
header that contained a single class that was in a list of special
classes.

Now, Div creation is _also_ triggered by a Blockquote that begins with a
header that has it's text contained in a list of special titles. The
title is used to lookup an appropriate class to give the Div.

In particular, 'prerequisites' is a special title, giving the class
'prereq'.

This input:

```
> ## Prerequisites
>
> A short paragraph describing what learners need to know before
> tackling this lesson.
```

will trigger this output:

```
<div id="prerequisites" class="prereq">
<h2>Prerequisites</h2>
<p>A short paragraph describing what learners need to know before
tackling this lesson.</p>
</div>
```
