### PR TITLE
fill in missing '$ ' in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ the `gh-pages` branch of their lesson website.  To do this:
    filters for Pandoc:
 
     ~~~
-    pip install pandocfilters
+    $ pip install pandocfilters
     ~~~
 
 3. To convert Markdown files into HTML pages in the root directory, go


### PR DESCRIPTION
We should be consistent with the code blocks that are meant to be executed in the shell.

Personally, I don't like having `$` before commands. I think it is less readable, confusing (is `$` a command?), and makes copy-paste more difficult. I would sooner remove it everywhere, but we should at least be consistent.

Any thoughts about removing `$` everywhere? Or is it more conventional than I think? This would apply to the workshop-template as well.
