### PR TITLE
Update validator for changes in directory structure

### DIFF
--- a/tools/check
+++ b/tools/check
@@ -59,8 +59,7 @@ class MarkdownValidator(object):
         if filename:
             # Expect Markdown files to be in same directory as the input file
             self.markdown_dir = os.path.dirname(filename)
-            self.lesson_dir = os.path.abspath(  # Parent directory of lesson
-                os.path.join(self.markdown_dir, os.pardir))
+            self.lesson_dir = self.markdown_dir
             with open(filename, 'rU') as f:
                 self.markdown = f.read()
         else:
@@ -68,7 +67,7 @@ class MarkdownValidator(object):
             self.lesson_dir = os.path.abspath(
                 os.path.join(os.path.dirname(__file__), os.pardir))
 
-            self.markdown_dir = os.path.join(self.lesson_dir, "pages")
+            self.markdown_dir = self.lesson_dir
             self.markdown = markdown
 
         ast = self._parse_markdown(self.markdown)
@@ -217,7 +216,8 @@ class MarkdownValidator(object):
 
         if re.match(r"^[\w,\s-]+\.(html?)", dest, re.IGNORECASE):
             # HTML files in same folder are made from Markdown; special tests
-            expected_md_fn = os.path.splitext(dest)[0] + os.extsep + "md"
+            fn = dest.split("#")[0]  # Split anchor name from filename
+            expected_md_fn = os.path.splitext(fn)[0] + os.extsep + "md"
             expected_md_path = os.path.join(self.markdown_dir,
                                             expected_md_fn)
             if not os.path.isfile(expected_md_path):
@@ -531,6 +531,9 @@ LESSON_TEMPLATES = {"index": (IndexPageValidator, "^index"),
                     "license": (LicensePageValidator, "^LICENSE"),
                     "discussion": (DiscussionPageValidator, "^discussion")}
 
+# List of files in the lesson directory that should not be validated at all
+SKIP_FILES = ("DESIGN.md", "FAQ.md", "LAYOUT.md", "README.md")
+
 
 def identify_template(filepath):
     """Identify template
@@ -546,6 +549,10 @@ def identify_template(filepath):
 
 def validate_single(filepath, template=None):
     """Validate a single Markdown file based on a specified template"""
+    if os.path.basename(filepath) in SKIP_FILES:
+        # Silently pass certain non-lesson files without validating them
+        return True
+
     template = template or identify_template(filepath)
     if template is None:
         logging.error(

--- a/tools/test_check.py
+++ b/tools/test_check.py
@@ -7,6 +7,9 @@ check = imp.load_source("check",  # Import non-.py file
 # Make log messages visible to help audit test failures
 check.start_logging(level=logging.DEBUG)
 
+MARKDOWN_DIR = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), os.pardir))
+
 
 class BaseTemplateTest(unittest.TestCase):
     """Common methods for testing template validators"""
@@ -22,7 +25,7 @@ class BaseTemplateTest(unittest.TestCase):
 
 
 class TestAstHelpers(BaseTemplateTest):
-    SAMPLE_FILE = '../pages/index.md'
+    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, 'index.md')
     VALIDATOR = check.MarkdownValidator
 
     def test_link_text_extracted(self):
@@ -38,7 +41,7 @@ class TestAstHelpers(BaseTemplateTest):
 class TestIndexPage(BaseTemplateTest):
     """Test the ability to correctly identify and validate specific sections
         of a markdown file"""
-    SAMPLE_FILE = "../pages/index.md"
+    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "index.md")
     VALIDATOR = check.IndexPageValidator
 
     def test_sample_file_passes_validation(self):
@@ -250,7 +253,7 @@ SQLite uses the integers 0 and 1 for the former, and represents the latter as di
 
 class TestTopicPage(BaseTemplateTest):
     """Verifies that the topic page validator works as expected"""
-    SAMPLE_FILE = "../pages/01-one.md"
+    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "01-one.md")
     VALIDATOR = check.TopicPageValidator
 
     def test_sample_file_passes_validation(self):
@@ -260,7 +263,7 @@ class TestTopicPage(BaseTemplateTest):
 
 class TestMotivationPage(BaseTemplateTest):
     """Verifies that the instructors page validator works as expected"""
-    SAMPLE_FILE = "../pages/motivation.md"
+    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "motivation.md")
     VALIDATOR = check.MotivationPageValidator
 
     def test_sample_file_passes_validation(self):
@@ -270,7 +273,7 @@ class TestMotivationPage(BaseTemplateTest):
 
 class TestReferencePage(BaseTemplateTest):
     """Verifies that the reference page validator works as expected"""
-    SAMPLE_FILE = "../pages/reference.md"
+    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "reference.md")
     VALIDATOR = check.ReferencePageValidator
 
     def test_missing_glossary_definition(self):
@@ -329,7 +332,7 @@ Key Word 2
 
 class TestInstructorPage(BaseTemplateTest):
     """Verifies that the instructors page validator works as expected"""
-    SAMPLE_FILE = "../pages/instructors.md"
+    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "instructors.md")
     VALIDATOR = check.InstructorPageValidator
 
     def test_sample_file_passes_validation(self):
@@ -338,7 +341,7 @@ class TestInstructorPage(BaseTemplateTest):
 
 
 class TestLicensePage(BaseTemplateTest):
-    SAMPLE_FILE = '../pages/LICENSE.md'
+    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "LICENSE.md")
     VALIDATOR = check.LicensePageValidator
 
     def test_sample_file_passes_validation(self):
@@ -354,7 +357,7 @@ class TestLicensePage(BaseTemplateTest):
 
 
 class TestDiscussionPage(BaseTemplateTest):
-    SAMPLE_FILE = '../pages/discussion.md'
+    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "discussion.md")
     VALIDATOR = check.DiscussionPageValidator
 
     def test_sample_file_passes_validation(self):


### PR DESCRIPTION
Updated validator and tests to reflect the new directory structure (markdown files live in lesson directory, not pages/). fix swcarpentry/lesson-template/#46
