### PR TITLE
Use INFO for http link verification

### DIFF
--- a/tools/check
+++ b/tools/check
@@ -259,7 +259,7 @@ class MarkdownValidator(object):
                         self.filename, dest, dest_path))
                 return False
         else:
-            logging.warning(
+            logging.info(
                 "In {0}: "
                 "Skipped validation of link {1}".format(self.filename, dest))
         return True


### PR DESCRIPTION
`tools/check` will not check if `https?:\/\/.*` links exist. Instead of a warning just write it for debug.
