### PR TITLE
Improve message for glossary error

### DIFF
--- a/tools/check
+++ b/tools/check
@@ -426,13 +426,14 @@ class ReferencePageValidator(MarkdownValidator):
         ```definition_lists``` extension.
 
         That syntax isn't supported by the CommonMark parser, so we identify
-         terms manually."""
+        terms manually."""
+        glossary_keyword = glossary_entry[0]
         if len(glossary_entry) < 2:
             logging.error(
                     "In {0}:"
-                    "Glossary entry must have at least two lines- "
+                    "Glossary entry \"{}\" must have at least two lines- "
                     "a term and a definition.".format(
-                        self.filename))
+                        glossary_keyword, self.filename))
             return False
 
         entry_is_valid = True
@@ -441,17 +442,19 @@ class ReferencePageValidator(MarkdownValidator):
                 if not re.match("^:   ", line):
                     logging.error(
                             "In {0}:"
+                            "At glossary entry \"{}\" "
                             "First line of definition must "
                             "start with ':    '.".format(
-                                self.filename))
+                                glossary_keyword, self.filename))
                     entry_is_valid = False
             elif line_index > 1:
                 if not re.match("^    ", line):
                     logging.error(
                             "In {0}:"
+                            "At glossary entry \"{}\" "
                             "Subsequent lines of definition must "
                             "start with '     '.".format(
-                                self.filename))
+                                glossary_keyword, self.filename))
                     entry_is_valid = False
         return entry_is_valid
 

--- a/tools/check
+++ b/tools/check
@@ -431,7 +431,7 @@ class ReferencePageValidator(MarkdownValidator):
         if len(glossary_entry) < 2:
             logging.error(
                     "In {0}:"
-                    "Glossary entry \"{}\" must have at least two lines- "
+                    "Glossary entry '{1}' must have at least two lines- "
                     "a term and a definition.".format(
                         glossary_keyword, self.filename))
             return False
@@ -442,7 +442,7 @@ class ReferencePageValidator(MarkdownValidator):
                 if not re.match("^:   ", line):
                     logging.error(
                             "In {0}:"
-                            "At glossary entry \"{}\" "
+                            "At glossary entry '{1}' "
                             "First line of definition must "
                             "start with ':    '.".format(
                                 glossary_keyword, self.filename))
@@ -451,7 +451,7 @@ class ReferencePageValidator(MarkdownValidator):
                 if not re.match("^    ", line):
                     logging.error(
                             "In {0}:"
-                            "At glossary entry \"{}\" "
+                            "At glossary entry '{1}' "
                             "Subsequent lines of definition must "
                             "start with '     '.".format(
                                 glossary_keyword, self.filename))


### PR DESCRIPTION
When a glossary entry has some error, mention the entry to the user. This will make easy for user fix it.
