### PR TITLE
Make templates consistent with how links are checked

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,5 +18,5 @@ Paragraph of introductory material.
 
 *   [Motivation](motivation.html)
 *   [Reference Guide](reference.html)
-*   [Next Steps](discussion.html)
+*   [Discussion](discussion.html)
 *   [Instructor's Guide](instructors.html)

--- a/motivation.md
+++ b/motivation.md
@@ -1,6 +1,6 @@
 ---
 layout: slides
-title: Why Topic?
+title: Lesson Title
 subtitle: Motivation
 ---
 <section class="slide">

--- a/motivation.md
+++ b/motivation.md
@@ -1,6 +1,7 @@
 ---
 layout: slides
 title: Why Topic?
+subtitle: Motivation
 ---
 <section class="slide">
 ## Why Topic?

--- a/reference.md
+++ b/reference.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Lesson Title
-subtitle: Reference
+subtitle: Reference Guide
 ---
 ...commands and examples...
 

--- a/tools/check
+++ b/tools/check
@@ -337,12 +337,6 @@ class IndexPageValidator(MarkdownValidator):
                     self.filename))
         return intro_section and prereqs_tests
 
-    def _validate_links(self, links_to_skip=('motivation.html',
-                                             'reference.html',
-                                             'discussion.html',
-                                             'instructors.html')):
-        return super(IndexPageValidator, self)._validate_links(links_to_skip)
-
     def _run_tests(self):
         tests = [self._validate_intro_section()]
         parent_tests = super(IndexPageValidator, self)._run_tests()
@@ -406,7 +400,8 @@ class TopicPageValidator(MarkdownValidator):
 class MotivationPageValidator(MarkdownValidator):
     """Validate motivation.md"""
     DOC_HEADERS = {"layout": vh.is_str,
-                   "title": vh.is_str}
+                   "title": vh.is_str,
+                   "subtitle": vh.is_str}
     # TODO: How to validate? May be a mix of reveal.js (HTML) + markdown.
 
 


### PR DESCRIPTION
These changes would enable simpler, more consistent link validation by changing the sample files so that they all follow the same rules. Yes, the validator is that pedantic... sorry, @gvwilson . ;)

This is an alternate proposal that would allow us to eliminate special casing for links to `index.html`, `discussion.html`, `reference.html`, and `motivation.html`. It is in reference to comments on another pull request: swcarpentry/lesson-template/#58
### What to merge

Changes to .md files can be merged as-is. 

If there are conflicts in tools/check, take the other version. The validator edits herein are solely meant to demonstrate that when the template is consistent, pages will validate without resorting to special-casing and complex code.

I added an extra YAML header to motivation.md. It doesn't seem to change the resulting HTML- confirm?
### Background

When the validator sees a link to a local .md file, it checks that:
a. There is a matching .md file, and
b. The text of the link matches the _subtitle_ YAML header of the destination file.

In their current form, some pages did not follow these rules. (eg index.md linked to "Discussion" as "Next Steps", and motivation.md did not have a subtitle node to check for rule b).
