### PR TITLE
Make filter for id at definitions general

### DIFF
--- a/tools/filters/id4glossary.py
+++ b/tools/filters/id4glossary.py
@@ -24,12 +24,11 @@ def keyword2html(keyword_node):
 
 def id4glossary(key, value, format, meta):
     """Add id to keywords at glossary."""
-    if "subtitle" in meta and pf.stringify(meta['subtitle']) == 'Reference':
-        if key == "DefinitionList":
-            for definition in value:
-                definition[0] = keyword2html(definition[0])
-            return {"t": key,
-                    "c": value}
+    if key == "DefinitionList":
+        for definition in value:
+            definition[0] = keyword2html(definition[0])
+        return {"t": key,
+                "c": value}
 
 if __name__ == '__main__':
     pf.toJSONFilter(id4glossary)


### PR DESCRIPTION
This solves #77 by add id attribute to every item of a definition.

I don't see big problems in

```
Foo
:   Some text
```

be convert to

```
<dl>
<dt><span id="foo">Foo</span></dt>
<dd>Some text
</dd>
</dl>
```

in every file of the lesson.

@gvwilson and @abought Comments?
