### PR TITLE
Improve logging of YAML header errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 CommonMark
 pandocfilters
+PyYAML

--- a/tools/test_check.py
+++ b/tools/test_check.py
@@ -60,7 +60,6 @@ class TestIndexPage(BaseTemplateTest):
 
 layout: lesson
 title: Lesson Title
-keywords: ["some", "key terms", "in a list"]
 
 Another section that isn't an HR
 """)
@@ -71,7 +70,6 @@ Another section that isn't an HR
         """One of the required headers is missing"""
         validator = self._create_validator("""---
 layout: lesson
-keywords: ["some", "key terms", "in a list"]
 ---""")
         self.assertFalse(validator._validate_doc_headers())
 
@@ -80,16 +78,14 @@ keywords: ["some", "key terms", "in a list"]
         validator = self._create_validator("""---
 layout: lesson
 title: Lesson Title
-keywords: ["some", "key terms", "in a list"]
 otherline: Nothing
 ---""")
         self.assertFalse(validator._validate_doc_headers())
 
-    def test_headers_fail_because_invalid_content(self):
+    def test_fail_when_headers_not_yaml_dict(self):
+        """Fail when the headers can't be parsed to a dict of YAML data"""
         validator = self._create_validator("""---
-layout: lesson
-title: Lesson Title
-keywords: this is not a list
+This will parse as a string, not a dictionary
 ---""")
         self.assertFalse(validator._validate_doc_headers())
 
@@ -155,7 +151,6 @@ Paragraph of introductory material.
         validator = self._create_validator("""---
 layout: lesson
 title: Lesson Title
-keywords: ["some", "key terms", "in a list"]
 ---
 Paragraph of introductory material.
 
@@ -182,7 +177,6 @@ Paragraph of introductory material.
         validator = self._create_validator("""---
 layout: lesson
 title: Lesson Title
-keywords: ["some", "key terms", "in a list"]
 ---
 Paragraph of introductory material.
 
@@ -197,7 +191,6 @@ Paragraph of introductory material.
         validator = self._create_validator("""---
 layout: lesson
 title: Lesson Title
-keywords: ["some", "key terms", "in a list"]
 ---
 Paragraph of introductory material.
 
@@ -291,6 +284,16 @@ class TestTopicPage(BaseTemplateTest):
     """Verifies that the topic page validator works as expected"""
     SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "01-one.md")
     VALIDATOR = check.TopicPageValidator
+
+    def test_headers_fail_because_invalid_content(self):
+        """The value provided as YAML does not match the expected datatype"""
+        validator = self._create_validator("""---
+layout: lesson
+title: Lesson Title
+subtitle: A page
+minutes: not a number
+---""")
+        self.assertFalse(validator._validate_doc_headers())
 
     def test_sample_file_passes_validation(self):
         sample_validator = self.VALIDATOR(self.SAMPLE_FILE)


### PR DESCRIPTION
Improve logging based on review of swcarpentry/matlab-novice-inflammation/#4 testcase.

Specifically, if the sample file is missing some fields from the YAML header section, those fields should be explicitly named in an error message.

Additionally: If custom tests are added to the base validator, they should run last. That way common error messages appear in a more logical and predictable order.
