### PR TITLE
Fix blockquote header attributes

### DIFF
--- a/tools/filters/blockquote2div.py
+++ b/tools/filters/blockquote2div.py
@@ -107,9 +107,8 @@ def blockquote2div(key, value, format, meta):
         ltitle = pf.stringify(inlines).lower()
         if ltitle in SPECIAL_TITLES:
             classes.append(SPECIAL_TITLES[ltitle])
-            return pf.Div(attr, blockquote)
 
-        elif len(classes) == 1 and classes[0] in SPECIAL_CLASSES:
+        if len(classes) == 1 and classes[0] in SPECIAL_CLASSES:
             remove_attributes(blockquote)
             # a blockquote is just a list of blocks, so it can be
             # passed directly to Div, which expects Div(attr, blocks)

--- a/tools/filters/blockquote2div.py
+++ b/tools/filters/blockquote2div.py
@@ -104,9 +104,9 @@ def blockquote2div(key, value, format, meta):
 
         id, classes, kvs = attr
 
-        ltitle = pf.stringify(inlines).lower()
-        if ltitle in SPECIAL_TITLES:
-            classes.append(SPECIAL_TITLES[ltitle])
+        lowercase_title = pf.stringify(inlines).lower()
+        if lowercase_title in SPECIAL_TITLES:
+            classes.append(SPECIAL_TITLES[lowercase_title])
 
         if len(classes) == 1 and classes[0] in SPECIAL_CLASSES:
             remove_attributes(blockquote)


### PR DESCRIPTION
@r-gaia-cs, see #59. Attributes were mistakenly being left on headers in blockquotes by the `blockquote2div` filter.
