### PR TITLE
automatically populate footer with git variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Auto Configuration
+GH_SITE = $$(git remote -v | grep -P 'origin.*\(push\)' | perl -pe 's,origin\s*(?:git@|https://|git://)github.com[:/]([\w-]*)/([\w-]*)\s*\(push\),https://github.com/\1/\2,')
+AUTHOR_EMAIL = $$(git config user.email)
+
 # Files.
 MARKDOWN = $(wildcard *.md)
 EXCLUDES = README.md LAYOUT.md FAQ.md DESIGN.md
@@ -11,7 +15,7 @@ FILTERS = $(wildcard tools/filters/*.py)
 INCLUDES = \
 	-Vheader="$$(cat _includes/header.html)" \
 	-Vbanner="$$(cat _includes/banner.html)" \
-	-Vfooter="$$(cat _includes/footer.html)" \
+	-Vfooter="$$(echo '' | pandoc --template _includes/footer.html -Vemail=$(AUTHOR_EMAIL) -Vsite=$(GH_SITE))" \
 	-Vjavascript="$$(cat _includes/javascript.html)"
 
 # Default action is to show what commands are available.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div class="footer">
-  <a class="label swc-blue-bg" href="mailto:admin@software-carpentry.org">Email</a>
-  <a class="label swc-blue-bg" href="http://github.com/swcarpentry">GitHub</a>
+  <a class="label swc-blue-bg" href="mailto:$email$">Email</a>
+  <a class="label swc-blue-bg" href="$site$">GitHub</a>
   <a class="label swc-blue-bg" href="LICENSE.html">License</a>
   <a class="bugreport label swc-blue-bg" href="mailto:admin@software-carpentry.org?subject=bug%20in%20{{page.path}}">Bug Report</a>
 </div>


### PR DESCRIPTION
Attempt at a zero-config fix to #52.

The footer contains a link to the github repository and an email
address. These will vary by lesson. To avoid configuration,
automatically determine what these should be by looking at the output
from `git config user.email` and inspecting `git remote -v`.
