### PR TITLE
Adding url placeholder

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 ---
-layout: lesson
+layout: page
 title: Licenses
 ---
 ### Instructional Material

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div class="footer">
-  <a class="label swc-blue-bg" href="mailto:admin@software-carpentry.org">Email</a>
-  <a class="label swc-blue-bg" href="http://github.com/swcarpentry">GitHub</a>
+  <a class="label swc-blue-bg" href="http://software-carpentry.org">Software Carpentry</a>
+  <a class="label swc-blue-bg" href="https://github.com/swcarpentry/lesson-template">Source</a>
+  <a class="label swc-blue-bg" href="mailto:admin@software-carpentry.org">Contact</a>
   <a class="label swc-blue-bg" href="LICENSE.html">License</a>
-  <a class="bugreport label swc-blue-bg" href="mailto:admin@software-carpentry.org?subject=bug%20in%20{{page.path}}">Bug Report</a>
 </div>


### PR DESCRIPTION
The original plan was to put the URL for this repository in a configuration file that authors could edit when creating actual lessons.  However, it looks like Pandoc only does one level of variable expansion, so variables inside `_includes/footer.html` (which is itself interpolated as a variable) aren't expanded.  Instead, we will tell authors to edit `_includes/footer.html` in the `README.md` in the `gh-pages` branch.
