### PR TITLE
Add requirements.txt necessary to build and run validator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+CommonMark
+pandocfilters


### PR DESCRIPTION
Replaces #100 and supplements #101: adds requirements.txt to the `core` branch. This commit contains only requirements.txt (not README.md). Tested on clean virtual env (python 2).

This commit is a complete copy of the file from #101 .
