### PR TITLE
Make validator imports more pythonic

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -20,21 +20,7 @@ import os
 import re
 import sys
 
-try:
-    # Code tested with CommonMark version 0.5.4; API may change
-    import CommonMark
-except ImportError:
-    ERROR_MESSAGE = """This program requires the CommonMark python package.
-Install using
-
-    # pip install commonmark
-
-or
-
-    # easy_install commonmark
-"""
-    print(ERROR_MESSAGE)
-    sys.exit(1)
+import CommonMark
 
 import validation_helpers as vh
 

--- a/tools/test_check.py
+++ b/tools/test_check.py
@@ -7,14 +7,11 @@ Some of these tests require looking for example files, which exist only on
 the gh-pages branch.   Some tests may therefore fail on branch "core".
 """
 
-
-import imp
 import logging
 import os
 import unittest
 
-check = imp.load_source("check",  # Import non-.py file
-                        os.path.join(os.path.dirname(__file__), "check"))
+import check
 
 # Make log messages visible to help audit test failures
 check.start_logging(level=logging.DEBUG)


### PR DESCRIPTION
Simple commit, but I got tired of `checkc` not being picked up as a .pyc file for the purpose of .gitignore.
1. This adds a .py extension to the validator to better follow convention and avoid complicated workarounds for python import machinery
2. Removes the try/except block for dependency, in favor of requirements.txt

If we really want the short form, we can add a target (`make check`) to the makefile.

Using the file extension is consistent with python convention, as well as the validator in workshop_template. Confirmed works in python 2 and 3.
