### PR TITLE
Improving support for R Markdown.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-# Files.
-MARKDOWN = $(wildcard *.md)
-EXCLUDES = README.md LAYOUT.md FAQ.md DESIGN.md
-SRC_PAGES = $(filter-out $(EXCLUDES), $(MARKDOWN))
-DST_PAGES = $(patsubst %.md,%.html,$(SRC_PAGES))
+# R Markdown files.
+SRC_RMD = $(wildcard ??-*.Rmd)
+DST_RMD = $(patsubst %.Rmd,%.md,$(SRC_RMD))
 
-# Pandoc filters
-FILTERS = $(wildcard tools/filters/*.py)
+# All Markdown files (hand-written and generated).
+SRC_MD = $(wildcard *.md) $(DST_RMD)
+DST_HTML = $(patsubst %.md,%.html,$(SRC_MD))
+
+# All outputs.
+DST_ALL = $(DST_HTML)
 
 # Inclusions.
 INCLUDES = \
@@ -14,11 +16,14 @@ INCLUDES = \
 	-Vfooter="$$(cat _includes/footer.html)" \
 	-Vjavascript="$$(cat _includes/javascript.html)"
 
+# Chunk options for knitr (used in R conversion).
+R_CHUNK_OPTS = tools/chunk-options.R
+
 # Default action is to show what commands are available.
 all : commands
 
 ## preview  : Build website locally for checking.
-preview : $(DST_PAGES)
+preview : $(DST_ALL)
 
 # Pattern for slides (different parameters and template).
 motivation.html : motivation.md _layouts/slides.html
@@ -27,7 +32,7 @@ motivation.html : motivation.md _layouts/slides.html
 	-o $@ $<
 
 # Pattern to build a generic page.
-%.html : %.md _layouts/page.html $(FILTERS)
+%.html : %.md _layouts/page.html
 	pandoc -s -t html \
 	--template=_layouts/page \
 	--filter=tools/filters/blockquote2div.py \
@@ -35,14 +40,14 @@ motivation.html : motivation.md _layouts/slides.html
 	$(INCLUDES) \
 	-o $@ $<
 
-# Pattern to convert R Markdown to Markdown.
-%.md: %.Rmd $(R_CHUNK_OPTS)
-	Rscript -e "knitr::knit('$$(basename $<)', output = '$$(basename $@)')"
-
 ## unittest : Run unit test (for Python 2 and 3)
 unittest: tools/check.py tools/validation_helpers.py tools/test_check.py
 	cd tools/ && python2 test_check.py
 	cd tools/ && python3 test_check.py
+
+# Pattern to convert R Markdown to Markdown.
+%.md: %.Rmd $(R_CHUNK_OPTS)
+	Rscript -e "knitr::knit('$$(basename $<)', output = '$$(basename $@)')"
 
 ## commands : Display available commands.
 commands : Makefile
@@ -50,8 +55,10 @@ commands : Makefile
 
 ## settings : Show variables and settings.
 settings :
-	@echo 'SRC_PAGES:' $(SRC_PAGES)
-	@echo 'DST_PAGES:' $(DST_PAGES)
+	@echo 'SRC_RMD:' $(SRC_RMD)
+	@echo 'DST_RMD:' $(DST_RMD)
+	@echo 'SRC_MD:' $(SRC_MD)
+	@echo 'DST_HTML:' $(DST_HTML)
 
 ## clean    : Clean up temporary and intermediate files.
 clean :
@@ -59,4 +66,4 @@ clean :
 
 # very-clean : Remove generated HTML.
 very-clean :
-	@rm -f $(DST_PAGES)
+	@rm -f $(DST_MD)

--- a/tools/chunk-options.R
+++ b/tools/chunk-options.R
@@ -1,0 +1,26 @@
+# These settings control the behavior of all chunks in the novice R materials.
+# For example, to generate the lessons with all the output hidden, simply change
+# `results` from "markup" to "hide".
+# For more information on available chunk options, see
+# http://yihui.name/knitr/options#chunk_options
+
+library("knitr")
+opts_chunk$set(tidy = FALSE, results = "markup", comment = NA,
+               fig.align = "center")
+
+# The hooks below add html tags to the code chunks and their output so that they
+# are properly formatted when the site is built with jekyll.
+hook_in <- function(x, options) {
+  stringr::str_c("\n\n~~~{.r}\n",
+                 paste0(x, collapse="\n"),
+                 "\n~~~\n\n")
+}
+
+hook_out <- function(x, options) {
+  stringr::str_c("\n\n~~~{.output}\n",
+                   paste0(x, collapse="\n"),
+                 "\n~~~\n\n")
+}
+
+knit_hooks$set(source = hook_in, output = hook_out, warning = hook_out,
+               error = hook_out, message = hook_out)


### PR DESCRIPTION
1.  Adding `tools/chunk-options.R` with support for Pandoc-based conversion of R Markdown to plain Markdown.
2.  Modifying `Makefile` to handle any R Markdown files that are present.

Changes have been checked by @jdblischak in the `r-novice-inflammation` project.
