### PR TITLE
Revamp validator to use Pandoc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-CommonMark
+pypandoc
 pandocfilters
 PyYAML

--- a/tools/filters/common.py
+++ b/tools/filters/common.py
@@ -1,0 +1,9 @@
+"""Common functions for filters"""
+
+def text2fragment_identifier(text):
+    """Generate fragment identifier from text.
+
+    - Convert to lowercase.
+    - Replace white space with "-".
+    - Remove ' and "."""
+    return text.lower().replace(" ", "-").replace("'", "").replace('"', "")

--- a/tools/filters/id4glossary.py
+++ b/tools/filters/id4glossary.py
@@ -7,17 +7,12 @@ Usage:
 """
 import pandocfilters as pf
 
-def normalize_keyword(keyword):
-    """Normalize keyword for became id
-
-    - Replace white space with '-'
-    - Convert to lowercase"""
-    return keyword.lower().replace(' ', '-')
+import common
 
 def keyword2html(keyword_node):
     """Return HTML version of keyword with id."""
     keyword = pf.stringify(keyword_node)
-    id = normalize_keyword(keyword)
+    id = common.text2fragment_identifier(keyword)
     return [{"t": "Span",
              "c": [[id, [],[]],
                  keyword_node]}]


### PR DESCRIPTION
I talked with @abought that I want to replace CommonMark with Pandoc at our validator because this will save us to wrote workarounds for Pandoc extensions that we are using.

**This is an work in progress.** The major advantage to the "old" validator is that it check links to glossary (and others local links with anchors). I still need to fix some of the code that I removed due compatibility issues.
