### PR TITLE
Set fig.path in tools/chunk-options.R to send all plots to fig/

### DIFF
--- a/tools/chunk-options.R
+++ b/tools/chunk-options.R
@@ -6,7 +6,7 @@
 
 library("knitr")
 opts_chunk$set(tidy = FALSE, results = "markup", comment = NA,
-               fig.align = "center")
+               fig.align = "center", fig.path = "fig/")
 
 # The hooks below add html tags to the code chunks and their output so that they
 # are properly formatted when the site is built with jekyll.


### PR DESCRIPTION
This will cause all plots generated by R Markdown files that source tools/chunk-options.R to be saved in fig/.
