### PR TITLE
Skip mailto links in link validation

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -362,9 +362,10 @@ class MarkdownValidator(object):
             # Validate local html links have matching md file
             return self._validate_one_html_link(link_node,
                                                 check_text=check_text)
-        elif not re.match(r"^((https?|ftp)://.+)", dest, re.IGNORECASE)\
+        elif not re.match(r"^((https?|ftp)://.+)|mailto:",
+                          dest, re.IGNORECASE)\
                 and not re.match(r"^#.*", dest):
-            # If not web URL, and not anchor on same page, then
+            # If not web or email URL, and not anchor on same page, then
             #  verify that local file exists
             dest_path = os.path.join(self.lesson_dir, dest)
             dest_path = dest_path.split("#")[0]  # Split anchor from filename


### PR DESCRIPTION
Small fix: Do not try to find a matching local file when encountering a `mailto:` link.

This issue was discovered by running unit tests on newest sample `motivation.md` in `gh-pages` branch.
