### PR TITLE
Revert changes when validating glossary

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -461,7 +461,8 @@ class ReferencePageValidator(MarkdownValidator):
         ```definition_lists``` extension.
 
         That syntax isn't supported by the CommonMark parser, so we identify
-         terms manually."""
+        terms manually."""
+        glossary_keyword = glossary_entry[0]
         if len(glossary_entry) < 2:
             logging.error(
                 "In {0}: "


### PR DESCRIPTION
@abought noted that our validator at `gh-pages` branch isn't working properly. This is a quickly fix for this issue. The `core` branch looks good.

```
$ git show --name-only core 
commit 6a2f2c50a041ca4c437b90e930ad38486ffe0665
Merge: 98029a7 b3b1b38
Author: Raniere Silva <raniere@ime.unicamp.br>
Date:   Fri Feb 6 02:20:31 2015 +0100

    Merge pull request #160 from abought/link_validation_mailto

    Skip mailto links in link validation

$ git show core:tools/check.py | grep "glossary_keyword"
        glossary_keyword = glossary_entry[0]
                    self.filename, glossary_keyword))
                            self.filename, glossary_keyword))
                            self.filename,  glossary_keyword, ))
```
