### PR TITLE
Validator should fail when FIXME present

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -74,6 +74,19 @@ class MarkdownValidator(object):
         ast = parser.parse(markdown)
         return ast
 
+    def _validate_no_fixme(self):
+        """Validate that the file contains no lines marked 'FIXME'
+        This will be based on the raw markdown, not the ast"""
+        valid = True
+        for i, line in enumerate(self.markdown.splitlines()):
+            if re.search("FIXME", line, re.IGNORECASE):
+                logging.error(
+                    "In {0}: "
+                    "Line {1} contains FIXME, indicating "
+                    "work in progress".format(self.filename, i+1))
+                valid = False
+        return valid
+
     def _validate_hrs(self):
         """Validate header
 
@@ -418,7 +431,8 @@ class MarkdownValidator(object):
 
         Error trapping is handled by the validate() wrapper method.
         """
-        tests = [self._validate_doc_headers(),
+        tests = [self._validate_no_fixme(),
+                 self._validate_doc_headers(),
                  self._validate_section_heading_order(),
                  self._validate_callouts(),
                  self._validate_links()]

--- a/tools/test_check.py
+++ b/tools/test_check.py
@@ -353,6 +353,17 @@ A spacer paragraph
 """)
         self.assertFalse(validator._validate_callouts())
 
+    def test_fail_if_fixme_present_all_caps(self):
+        """Validation should fail if a line contains the word FIXME (exact)"""
+        validator = self._create_validator("""Incomplete sentence (FIXME).""")
+        self.assertFalse(validator._validate_no_fixme())
+
+    def test_fail_if_fixme_present_mixed_case(self):
+        """Validation should fail if a line contains the word FIXME
+        (in any capitalization)"""
+        validator = self._create_validator("""Incomplete sentence (FiXmE).""")
+        self.assertFalse(validator._validate_no_fixme())
+
 
 class TestTopicPage(BaseTemplateTest):
     """Verifies that the topic page validator works as expected"""


### PR DESCRIPTION
Several of our lesson authors use the label `FIXME` to indicate text that is a work in progress. 

This pull request ensures that the validator will remind them about unfinished lesson content. A markdown file will fail validation if the word `FIXME` (in any capitalization) is present anywhere in the file.

Please let me know if there any other common watchwords that we should check for.
