### PR TITLE
Minor fixes to license file.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 layout: page
 title: Licenses
 ---
-### Instructional Material
+## Instructional Material
 
 All Software Carpentry instructional material is made available under
 the [Creative Commons Attribution license][cc-by-human]. The following
@@ -43,12 +43,12 @@ Notices:
   rights such as publicity, privacy, or moral rights may limit how you
   use the material.
 
-### Software
+## Software
 
 Except where otherwise noted, the example programs and other software
 provided by Software Carpentry are made available under the
-[OSI](http://opensource.org)-approved
-[MIT license](http://opensource.org/licenses/mit-license.html).
+[OSI][osi]-approved
+[MIT license][mit-license].
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -69,16 +69,13 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-### Other Material
-
-Our [code of conduct](CODE_OF_CONDUCT.html) is taken from
-[this site](https://github.com/Bantik/contributor_covenant/blob/master/LICENSE),
-and is made available under the same MIT License as our software.
-
-### Trademark
+## Trademark
 
 "Software Carpentry" and the Software Carpentry logo are registered
-trademarks of Software Carpentry, Ltd.
+trademarks of [NumFOCUS][numfocus].
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
+[mit-license]: http://opensource.org/licenses/mit-license.html
+[numfocus]: http://numfocus.org/
+[osi]: http://opensource.org

--- a/tools/check.py
+++ b/tools/check.py
@@ -620,7 +620,7 @@ class LicensePageValidator(MarkdownValidator):
     def _run_tests(self):
         """Skip the base tests; just check md5 hash"""
         # TODO: This hash is specific to the license for english-language repo
-        expected_hash = 'cd5742b6596a1f2f35c602ad43fa24b2'
+        expected_hash = '051a04b8ffe580ba6b7018fb4fd72a50'
         m = hashlib.md5()
         try:
             m.update(self.markdown)


### PR DESCRIPTION
1.  Remove copyright information about code of conduct (which isn't in this repo).
2.  Change ownership of trademark to NumFOCUS.
3.  Use uniform link syntax.

Fixes #126.
