### PR TITLE
Another try to revamp tools/check.py to use Pandoc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-CommonMark
+pypandoc
 pandocfilters
 PyYAML

--- a/tools/filters/common.py
+++ b/tools/filters/common.py
@@ -1,0 +1,9 @@
+"""Common functions for filters"""
+
+def text2fragment_identifier(text):
+    """Generate fragment identifier from text.
+
+    - Convert to lowercase.
+    - Replace white space with "-".
+    - Remove ' and "."""
+    return text.lower().replace(" ", "-").replace("'", "").replace('"', "")

--- a/tools/filters/id4glossary.py
+++ b/tools/filters/id4glossary.py
@@ -7,17 +7,12 @@ Usage:
 """
 import pandocfilters as pf
 
-def normalize_keyword(keyword):
-    """Normalize keyword for became id
-
-    - Replace white space with '-'
-    - Convert to lowercase"""
-    return keyword.lower().replace(' ', '-')
+import common
 
 def keyword2html(keyword_node):
     """Return HTML version of keyword with id."""
     keyword = pf.stringify(keyword_node)
-    id = normalize_keyword(keyword)
+    id = common.text2fragment_identifier(keyword)
     return [{"t": "Span",
              "c": [[id, [],[]],
                  keyword_node]}]

--- a/tools/test_check.py
+++ b/tools/test_check.py
@@ -14,7 +14,7 @@ import unittest
 import check
 
 # Make log messages visible to help audit test failures
-check.start_logging(level=logging.DEBUG)
+check.start_logging(level=logging.CRITICAL)
 
 MARKDOWN_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), os.pardir))
@@ -22,7 +22,6 @@ MARKDOWN_DIR = os.path.abspath(
 
 class BaseTemplateTest(unittest.TestCase):
     """Common methods for testing template validators"""
-    SAMPLE_FILE = "" # Path to a file that should pass all tests
     VALIDATOR = check.MarkdownValidator
 
     def _create_validator(self, markdown):
@@ -30,64 +29,44 @@ class BaseTemplateTest(unittest.TestCase):
         return self.VALIDATOR(markdown=markdown)
 
 
-class TestAstHelpers(BaseTemplateTest):
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, 'index.md')
-    VALIDATOR = check.MarkdownValidator
-
-    def test_link_text_extracted(self):
-        """Verify that link text and destination are extracted correctly"""
-        validator = self._create_validator("""[This is a link](discussion.html)""")
-        links = validator.ast.find_external_links(validator.ast.children[0])
-
-        dest, link_text = validator.ast.get_link_info(links[0])
-        self.assertEqual(dest, "discussion.html")
-        self.assertEqual(link_text, "This is a link")
-
-
 class TestIndexPage(BaseTemplateTest):
     """Test the ability to correctly identify and validate specific sections
         of a markdown file"""
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "index.md")
     VALIDATOR = check.IndexPageValidator
 
-    def test_sample_file_passes_validation(self):
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator.validate()
-        self.assertTrue(res)
+    # TESTS INVOLVING DOCUMENT HEADER SECTION
+    def test_headers_missing_header(self):
+        validator = self._create_validator("""Blank row""")
 
-    def test_headers_missing_hrs(self):
-        validator = self._create_validator("""Blank row
-
-layout: lesson
-title: Lesson Title
-
-Another section that isn't an HR
-""")
-
-        self.assertFalse(validator._validate_doc_headers())
+        self.assertFalse(validator._validate_header())
 
     def test_headers_missing_a_line(self):
         """One of the required headers is missing"""
         validator = self._create_validator("""---
 layout: lesson
 ---""")
-        self.assertFalse(validator._validate_doc_headers())
+        self.assertFalse(validator._validate_header())
 
-    # TESTS INVOLVING DOCUMENT HEADER SECTION
     def test_headers_fail_with_other_content(self):
         validator = self._create_validator("""---
 layout: lesson
 title: Lesson Title
 otherline: Nothing
 ---""")
-        self.assertFalse(validator._validate_doc_headers())
+        self.assertFalse(validator._validate_header())
 
     def test_fail_when_headers_not_yaml_dict(self):
-        """Fail when the headers can't be parsed to a dict of YAML data"""
+        """Fail when the headers can't be parsed to a dict of YAML data
+
+        This will print ::
+
+            pandoc: YAML header is not an object "source" (line 1, column 1)
+
+        to stderr."""
         validator = self._create_validator("""---
 This will parse as a string, not a dictionary
 ---""")
-        self.assertFalse(validator._validate_doc_headers())
+        self.assertFalse(validator._validate_header())
 
     # TESTS INVOLVING SECTION TITLES/HEADINGS
     def test_index_has_valid_section_headings(self):
@@ -103,8 +82,7 @@ This will parse as a string, not a dictionary
 *   [Reference Guide](reference.html)
 *   [Next Steps](discussion.html)
 *   [Instructor's Guide](instructors.html)""")
-        res = validator._validate_section_heading_order()
-        self.assertTrue(res)
+        self.assertTrue(validator._validate_headings_order())
 
     def test_index_fail_when_section_heading_absent(self):
         validator = self._create_validator("""## Topics
@@ -118,7 +96,7 @@ This will parse as a string, not a dictionary
 *   [Reference Guide](reference.html)
 *   [Next Steps](discussion.html)
 *   [Instructor's Guide](instructors.html)""")
-        res = validator.ast.has_section_heading("Fake heading")
+        res = validator._validate_header()
         self.assertFalse(res)
 
     def test_fail_when_section_heading_is_wrong_level(self):
@@ -145,7 +123,7 @@ Paragraph of introductory material.
 *   [Reference Guide](reference.html)
 *   [Next Steps](discussion.html)
 *   [Instructor's Guide](instructors.html)""")
-        self.assertFalse(validator._validate_section_heading_order())
+        self.assertFalse(validator._validate_headings_order())
 
     def test_fail_when_section_headings_in_wrong_order(self):
         validator = self._create_validator("""---
@@ -171,7 +149,7 @@ Paragraph of introductory material.
 * [Topic Title 1](01-one.html)
 * [Topic Title 2](02-two.html)""")
 
-        self.assertFalse(validator._validate_section_heading_order())
+        self.assertFalse(validator._validate_headings_order())
 
     def test_pass_when_prereq_section_has_correct_heading_level(self):
         validator = self._create_validator("""---
@@ -194,51 +172,7 @@ Paragraph of introductory material.
 > A short paragraph describing what learners need to know
 > before tackling this lesson.
 """)
-        self.assertFalse(validator._validate_callouts())
-
-    # TESTS INVOLVING LINKS TO OTHER CONTENT
-    def test_should_check_text_of_all_links_in_index(self):
-        """Text of every local-html link in index.md should
-        match dest page title"""
-        validator = self._create_validator("""
-## [This link is in a heading](reference.html)
-[Topic Title One](01-one.html#anchor)""")
-        links = validator.ast.find_external_links()
-        check_text, dont_check_text = validator._partition_links()
-
-        self.assertEqual(len(dont_check_text), 0)
-        self.assertEqual(len(check_text), 2)
-
-    def test_file_links_validate(self):
-        """Verify that all links in a sample file validate.
-        Involves checking for example files; may fail on "core" branch"""
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator._validate_links()
-        self.assertTrue(res)
-
-    def test_html_link_to_extant_md_file_passes(self):
-        """Verify that an HTML link with corresponding MD file will pass
-        Involves checking for example files; may fail on "core" branch"""
-        validator = self._create_validator("""[Topic Title One](01-one.html)""")
-        self.assertTrue(validator._validate_links())
-
-    def test_html_link_with_anchor_to_extant_md_passes(self):
-        """Verify that link is identified correctly even if to page anchor
-
-        For now this just tests that the regex handles #anchors.
-         It doesn't validate that the named anchor exists in the md file
-
-        Involves checking for example files; may fail on "core" branch
-        """
-        validator = self._create_validator("""[Topic Title One](01-one.html#anchor)""")
-        self.assertTrue(validator._validate_links())
-
-    def test_inpage_anchor_passes_validation(self):
-        """Links that reference anchors within the page should be ignored"""
-        # TODO: Revisit once anchor rules are available
-        validator = self._create_validator("""Most databases also support Booleans and date/time values;
-SQLite uses the integers 0 and 1 for the former, and represents the latter as discussed [earlier](#a:dates).""")
-        self.assertTrue(validator._validate_links())
+        self.assertFalse(validator._validate_boxes())
 
     def test_missing_markdown_file_fails_validation(self):
         """Fail validation when an html file is linked without corresponding
@@ -259,26 +193,11 @@ SQLite uses the integers 0 and 1 for the former, and represents the latter as di
         validator = self._create_validator("""[Broken link](www.website.com/filename.html)""")
         self.assertFalse(validator._validate_links())
 
-    def test_finds_image_asset(self):
-        """Image asset is found in the expected file location
-        Involves checking for example files; may fail on "core" branch"""
-        validator = self._create_validator(
-            """![this is the image's title](fig/example.svg "this is the image's alt text")""")
-        self.assertTrue(validator._validate_links())
-
     def test_image_asset_not_found(self):
         """Image asset can't be found if path is invalid"""
         validator = self._create_validator(
             """![this is the image's title](fig/exemple.svg "this is the image's alt text")""")
         self.assertFalse(validator._validate_links())
-
-    def test_non_html_link_finds_csv(self):
-        """Look for CSV file in appropriate folder
-        Involves checking for example files; may fail on "core" branch
-        """
-        validator = self._create_validator(
-            """Use [this CSV](data/data.csv) for the exercise.""")
-        self.assertTrue(validator._validate_links())
 
     def test_non_html_links_are_path_sensitive(self):
         """Fails to find CSV file with wrong path."""
@@ -286,14 +205,13 @@ SQLite uses the integers 0 and 1 for the former, and represents the latter as di
             """Use [this CSV](data.csv) for the exercise.""")
         self.assertFalse(validator._validate_links())
 
-    ### Tests involving callout/blockquote sections
     def test_one_prereq_callout_passes(self):
         """index.md should have one, and only one, prerequisites box"""
         validator = self._create_validator("""> ## Prerequisites {.prereq}
 >
 > What learners need to know before tackling this lesson.
 """)
-        self.assertTrue(validator._validate_callouts())
+        self.assertTrue(validator._validate_boxes())
 
     def test_two_prereq_callouts_fail(self):
         """More than one prereq callout box is not allowed"""
@@ -307,7 +225,7 @@ A spacer paragraph
 >
 > A second prerequisites box should cause an error
 """)
-        self.assertFalse(validator._validate_callouts())
+        self.assertFalse(validator._validate_boxes())
 
     def test_callout_without_style_fails(self):
         """A callout box will fail if it is missing the required style"""
@@ -315,7 +233,7 @@ A spacer paragraph
 >
 > What learners need to know before tackling this lesson.
 """)
-        self.assertFalse(validator._validate_callouts())
+        self.assertFalse(validator._validate_boxes())
 
     def test_callout_with_wrong_title_fails(self):
         """A callout box will fail if it has the wrong title"""
@@ -323,7 +241,7 @@ A spacer paragraph
 >
 > What learners need to know before tackling this lesson.
 """)
-        self.assertFalse(validator._validate_callouts())
+        self.assertFalse(validator._validate_boxes())
 
     def test_unknown_callout_style_fails(self):
         """A callout whose style is unrecognized by template is invalid"""
@@ -331,8 +249,7 @@ A spacer paragraph
 >
 > What learners need to know before tackling this lesson.
 """)
-        callout_node = validator.ast.get_callouts()[0]
-        self.assertFalse(validator._validate_one_callout(callout_node))
+        self.assertFalse(validator._validate_boxes())
 
     def test_block_ignored_sans_heading(self):
         """
@@ -342,7 +259,7 @@ A spacer paragraph
 >
 > What learners need to know before tackling this lesson.
 """)
-        callout_nodes = validator.ast.get_callouts()
+        callout_nodes = validator.ast.get_boxes()
         self.assertEqual(len(callout_nodes), 0)
 
     def test_callout_heading_must_be_l2(self):
@@ -351,7 +268,7 @@ A spacer paragraph
 >
 > What learners need to know before tackling this lesson.
 """)
-        self.assertFalse(validator._validate_callouts())
+        self.assertFalse(validator._validate_boxes())
 
     def test_fail_if_fixme_present_all_caps(self):
         """Validation should fail if a line contains the word FIXME (exact)"""
@@ -367,7 +284,6 @@ A spacer paragraph
 
 class TestTopicPage(BaseTemplateTest):
     """Verifies that the topic page validator works as expected"""
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "01-one.md")
     VALIDATOR = check.TopicPageValidator
 
     def test_headers_fail_because_invalid_content(self):
@@ -378,7 +294,7 @@ title: Lesson Title
 subtitle: A page
 minutes: not a number
 ---""")
-        self.assertFalse(validator._validate_doc_headers())
+        self.assertFalse(validator._validate_header())
 
     def test_topic_page_should_have_no_headings(self):
         """Requirement according to spec; may be relaxed in future"""
@@ -386,26 +302,7 @@ minutes: not a number
 ## Heading that should not be present
 
 Some text""")
-        self.assertFalse(validator._validate_has_no_headings())
-
-    def test_should_not_check_text_of_links_in_topic(self):
-        """Never check that text of local-html links in topic
-        matches dest title """
-        validator = self._create_validator("""
-## [This link is in a heading](reference.html)
-[Topic Title One](01-one.html#anchor)""")
-        links = validator.ast.find_external_links()
-        check_text, dont_check_text = validator._partition_links()
-
-        self.assertEqual(len(dont_check_text), 2)
-        self.assertEqual(len(check_text), 0)
-
-    def test_pass_when_optional_callouts_absent(self):
-        """Optional block titles should be optional"""
-        validator = self._create_validator("""> ## Learning Objectives {.objectives}
->
-> * All topic pages must have this callout""")
-        self.assertTrue(validator._validate_callouts())
+        self.assertFalse(validator._validate_header())
 
 
     def test_callout_style_passes_regardless_of_title(self):
@@ -419,7 +316,7 @@ Some text""")
 >
 > Some informative text""")
 
-        self.assertTrue(validator._validate_callouts())
+        self.assertTrue(validator._validate_boxes())
 
     def test_callout_style_allows_duplicates(self):
         """Multiple blockquoted sections with style 'callout' are allowed"""
@@ -436,54 +333,21 @@ Spacer paragraph
 > ## Callout box two {.callout}
 >
 > Further exposition""")
-        self.assertTrue(validator._validate_callouts())
-
-    def test_sample_file_passes_validation(self):
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator.validate()
-        self.assertTrue(res)
+        self.assertTrue(validator._validate_boxes())
 
 
 class TestMotivationPage(BaseTemplateTest):
     """Verifies that the instructors page validator works as expected"""
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "motivation.md")
     VALIDATOR = check.MotivationPageValidator
-
-    def test_sample_file_passes_validation(self):
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator.validate()
-        self.assertTrue(res)
 
 
 class TestReferencePage(BaseTemplateTest):
     """Verifies that the reference page validator works as expected"""
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "reference.md")
     VALIDATOR = check.ReferencePageValidator
 
     def test_missing_glossary_definition(self):
         validator = self._create_validator("")
-        self.assertFalse(validator._validate_glossary_entry(
-            ["Key word"]))
-
-    def test_missing_colon_at_glossary_definition(self):
-        validator = self._create_validator("")
-        self.assertFalse(validator._validate_glossary_entry(
-            ["Key word", "Definition of term"]))
-
-    def test_wrong_indentation_at_glossary_definition(self):
-        validator = self._create_validator("")
-        self.assertFalse(validator._validate_glossary_entry(
-            ["Key word", ": Definition of term"]))
-
-    def test_wrong_continuation_at_glossary_definition(self):
-        validator = self._create_validator("")
-        self.assertFalse(validator._validate_glossary_entry(
-            ["Key word", ":   Definition of term", "continuation"]))
-
-    def test_valid_glossary_definition(self):
-        validator = self._create_validator("")
-        self.assertTrue(validator._validate_glossary_entry(
-            ["Key word", ":   Definition of term", "    continuation"]))
+        self.assertFalse(validator._validate_glossary())
 
     def test_only_definitions_can_appear_after_glossary_heading(self):
         validator = self._create_validator("""## Glossary
@@ -498,94 +362,39 @@ Key Word 2
 """)
         self.assertFalse(validator._validate_glossary())
 
+    def test_definition_with_two_lines(self):
+        validator = self._create_validator("""## Glossary
+
+Key Word
+:   Definition of first term.
+    Second line of the definition.
+""")
+        self.assertTrue(validator._validate_glossary())
+
     def test_glossary(self):
         validator = self._create_validator("""## Glossary
 
 Key Word 1
 :   Definition of first term
+    Second line of the definition.
 
 Key Word 2
 :   Definition of second term
 """)
         self.assertTrue(validator._validate_glossary())
 
-    def test_callout_fails_when_none_specified(self):
-        """The presence of a callout box should cause validation to fail
-           when the template doesn't define any recognized callouts
-
-           (No "unknown" blockquote sections are allowed)
-           """
-        validator = self._create_validator("""> ## Learning Objectives {.objectives}
->
-> * Learning objective 1
-> * Learning objective 2""")
-
-        self.assertFalse(validator._validate_callouts())
-
-    def test_sample_file_passes_validation(self):
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator.validate()
-        self.assertTrue(res)
-
 
 class TestInstructorPage(BaseTemplateTest):
     """Verifies that the instructors page validator works as expected"""
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "instructors.md")
     VALIDATOR = check.InstructorPageValidator
-
-    def test_should_selectively_check_text_of_links_in_topic(self):
-        """Only verify that text of local-html links in topic
-        matches dest title if the link is in a heading"""
-        validator = self._create_validator("""
-## [Reference](reference.html)
-
-[Topic Title One](01-one.html#anchor)""")
-        check_text, dont_check_text = validator._partition_links()
-
-        self.assertEqual(len(dont_check_text), 1)
-        self.assertEqual(len(check_text), 1)
-
-    def test_link_dest_bad_while_text_ignored(self):
-        validator = self._create_validator("""
-[ignored text](nonexistent.html)""")
-        self.assertFalse(validator._validate_links())
-
-    def test_link_dest_good_while_text_ignored(self):
-        validator = self._create_validator("""
-[ignored text](01-one.html)""")
-        self.assertTrue(validator._validate_links())
-
-    def test_sample_file_passes_validation(self):
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator.validate()
-        self.assertTrue(res)
 
 
 class TestLicensePage(BaseTemplateTest):
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "LICENSE.md")
     VALIDATOR = check.LicensePageValidator
-
-    def test_sample_file_passes_validation(self):
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator.validate()
-        self.assertTrue(res)
-
-    def test_modified_file_fails_validation(self):
-        with open(self.SAMPLE_FILE, 'rU') as f:
-            orig_text = f.read()
-        mod_text = orig_text.replace("The", "the")
-        validator = self._create_validator(mod_text)
-        self.assertFalse(validator.validate())
 
 
 class TestDiscussionPage(BaseTemplateTest):
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "discussion.md")
     VALIDATOR = check.DiscussionPageValidator
-
-    def test_sample_file_passes_validation(self):
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator.validate()
-        self.assertTrue(res)
 
 
 if __name__ == "__main__":

--- a/tools/validation_helpers.py
+++ b/tools/validation_helpers.py
@@ -1,9 +1,14 @@
 #! /usr/bin/env python
 
-import json
 import logging
 import re
 import sys
+
+import json
+import pypandoc
+import pandocfilters
+
+import filters.common as fc
 
 try:  # Hack to make codebase compatible with python 2 and 3
   basestring
@@ -12,16 +17,9 @@ except NameError:
 
 
 # Common validation functions
-def is_list(text):
-    """Validate whether the provided string can be converted to python list"""
-    text = text.strip()
-    try:
-        text_as_list = json.loads(text)
-    except ValueError:
-        logging.debug("Could not convert string to python object: {0}".format(text))
-        return False
-
-    return isinstance(text_as_list, list)
+def ast_to_string(ast):
+    """Convert Pandoc AST to string."""
+    return pandocfilters.stringify(ast)
 
 
 def is_str(text):
@@ -37,206 +35,104 @@ def is_numeric(text):
     except ValueError:
         return False
 
+def is_blockquote(ast, position=0):
+    """Check if given node of AST is a blockquote."""
+    return ast[position] and ast[position]['t'] != "BlockQuote"
 
-#### Text cleanup functions, pre-validation
-def strip_attrs(s):
-    """Strip attributes of the form {.name} from a markdown title string"""
-    return re.sub(r"\s\{\..*?\}", "", s)
+def is_heading(ast, position=0):
+    """Check if given node of AST is a heading."""
+    return ast[position] and ast[position]['t'] != "Header"
 
+def is_paragraph(ast, position=0):
+    """Check if given node of AST is a paragraph."""
+    return ast[position] and ast[position]['t'] != "Para"
 
-def get_css_class(s):
-    """Return any and all CSS classes (when a line is suffixed by {.classname})
-    Returns empty list when """
-    return re.findall("\{\.(.*?)\}", s)
+def is_box(ast_node):
+    """Check if is a box, i.e.
+    blockquotes whose first child element is a heading"""
+    if (ast_node["t"] == "BlockQuote"
+        and len(ast_node["c"]) > 1
+        and ast_node["c"][0]["t"] == "Header"):
+        return True
+    else:
+        return False
 
+def get_node_content(ast, position):
+    """Return the content of the givem node of AST."""
+    return ast[position]['c']
+def get_box_level(ast_node):
+    """Return the level of the box."""
+    return ast_node["c"][0]["c"][0]
 
-### Helper objects
-class CommonMarkHelper(object):
-    """Basic helper functions for working with the internal abstract syntax
-    tree produced by CommonMark parser"""
-    def __init__(self, ast):
-        self.data = ast
-        self.children = self.data.children
+def get_box_title(ast_node):
+    """Return the title of the box."""
+    return ast_to_string(ast_node['c'][0])
 
-    def get_doc_header_title(self):
-        """Helper method for SWC templates: get the document title from
-        the YAML headers"""
-        doc_headers = self.data.children[1]  # Throw index error if none found
+def get_box_type(ast_node):
+    """Return the type of the box."""
+    box_type = ast_node['c'][0]['c'][1][1]
+    if len(box_type) > 0:
+        box_type = box_type[0]
+    else:
+        box_type = None
 
-        for s in doc_headers.strings:
-            label, contents = s.split(":", 1)
-            if label.lower() == "title":
-                return contents.strip()
+    return box_type
 
-        # If title not found, return an empty string for display purposes
-        return ''
+### Pandoc AST Helper
+class PandocAstHelper(object):
+    """Basic helper functions
+    for working with the internal abstract syntax tree (ast)
+    produced by Pandoc parser"""
+    def __init__(self, markdown):
+        self.header, self.body = self._parse_markdown(markdown)
 
-    def get_doc_header_subtitle(self):
-        """Helper method for SWC templates: get the document title from
-        the YAML headers"""
-        doc_headers = self.data.children[1]  # Throw index error if none found
+        self.anchors = []
 
-        for s in doc_headers.strings:
-            label, contents = s.split(":", 1)
-            if label.lower() == "subtitle":
-                return contents.strip()
+        def get_anchors(key, val, format, meta):
+            if key == "Header":
+                self.anchors.append(val[1][0])
+            if key == "DefinitionList":
+                for definition in val:
+                    self.anchors.append(fc.text2fragment_identifier(ast_to_string(definition[0])))
 
-        # If title not found, return an empty string for display purposes
-        return ''
+        pandocfilters.walk(self.body, get_anchors, "", {})
 
-    def get_block_titled(self, title, heading_level=2, ast_node=None):
-        """Examine children. Return all children of the given node that:
-        a) are blockquoted elements, and
-        b) contain a heading with the specified text, at the specified level.
-        For example, this can be used to find the "Prerequisites" section
-            in index.md
+    def _parse_markdown(self, markdown):
+        ast = json.loads(pypandoc.convert(''.join(markdown),
+                                          'json',
+                                          'markdown'))
+        return ast[0]["unMeta"], ast[1]
 
-        Returns empty list if no appropriate node is found"""
-
-        # TODO: Deprecate in favor of callout validator
-        if ast_node is None:
-            ast_node = self.data
-        return [n for n in ast_node.children
-                if self.is_block(n) and
-                self.has_section_heading(
-                    title,
-                    ast_node=n,
-                    heading_level=heading_level,
-                    show_msg=False)]
-
-    # Helpers to fetch specific document sections
-    def get_section_headings(self, ast_node=None):
-        """Returns a list of ast nodes that are headings"""
-        if ast_node is None:
-            ast_node = self.data
-        return [n for n in ast_node.children if self.is_heading(n)]
-
-    def get_callouts(self, ast_node=None):
-        if ast_node is None:
-            ast_node = self.data
-        return [n for n in ast_node.children if self.is_callout(n)]
-
-    def find_external_links(self, ast_node=None, parent_crit=None):
-        """Recursive function that locates all references to external content
-         under specified node. (links or images)"""
-        ast_node = ast_node or self.data
-        if parent_crit is None:
-            # User can optionally provide a function to filter link list
-            # based on where link appears. (eg, only links in headings)
-            # If no filter is provided, accept all links in that node.
-            parent_crit = lambda n: True
-
-        # Link can be node itself, or hiding in inline content
-        links = [n for n in ast_node.inline_content
-                 if self.is_external(n) and parent_crit(ast_node)]
-
-        if self.is_external(ast_node):
-            links.append(ast_node)
-
-        # Also look for links in sub-nodes
-        for n in ast_node.children:
-            links.extend(self.find_external_links(n,
-                                                  parent_crit=parent_crit))
-
-        return links
-
-    # Helpers to get information from a specific node type
-    def get_link_info(self, link_node):
-        """Given a link node, return the link title and destination"""
-        if not self.is_external(link_node):
-            raise TypeError("Cannot apply this method to something that is not a link")
-
-        dest = link_node.destination
-        try:
-            link_text = link_node.label[0].c
-        except:
-            link_text = None
-
-        return dest, link_text
-
-    def get_heading_info(self, heading_node):
-        """Get heading text and list of all css styles applied"""
-        heading = heading_node.strings[0]
-        text = strip_attrs(heading)
-        css = get_css_class(heading)
-        return text, css
-
-    # Functions to query type or content of nodes
-    def has_section_heading(self, section_title, ast_node=None,
-                            heading_level=2, limit=sys.maxsize, show_msg=True):
-        """Does the section contain (<= x copies of) specified heading text?
-        Will strip off any CSS attributes when looking for the section title"""
-        if ast_node is None:
-            ast_node = self.data
-
-        num_nodes = len([n for n in self.get_section_headings(ast_node)
-                         if (strip_attrs(n.strings[0]) == section_title)
-                         and (n.level == heading_level)])
-
-        # Suppress error msg if used as a helper method
-        if show_msg and num_nodes == 0:
-            logging.error("Document does not contain the specified "
-                          "heading: {0}".format(section_title))
-        elif show_msg and num_nodes > limit:
-            logging.error("Document must not contain more than {0} copies of"
-                          " the heading {1}".format(limit, section_title or 0))
-        elif show_msg:
-            logging.info("Verified that document contains the specified"
-                         " heading: {0}".format(section_title))
-        return (0 < num_nodes <= limit)
-
-    def has_number_children(self, ast_node,
-                            exact=None, minc=0, maxc=sys.maxsize):
-        """Does the specified node (such as a bulleted list) have the expected
-         number of children?"""
-
-        if exact:  # If specified, must have exactly this number of children
-            minc = maxc = exact
-
-        return (minc <= len(ast_node.children) <= maxc)
-
-    # Helpers, in case the evolving CommonMark spec changes the names of nodes
-    def is_hr(self, ast_node):
-        """Is the node a horizontal rule (hr)?"""
-        return ast_node.t == 'HorizontalRule'
-
-    def is_heading(self, ast_node, heading_level=None):
-        """Is the node a heading/ title?"""
-        has_tag = ast_node.t == "ATXHeader"
-
-        if heading_level is None:
-            has_level = True
+    def _get_info_from_header(self, keyword):
+        """Get the value for a keyword or None if the keyword doesn't exist."""
+        if keyword in self.header:
+            return ast_to_string(self.header["title"])
         else:
-            has_level = (ast_node.level == heading_level)
-        return has_tag and has_level
+            return None
 
-    def is_paragraph(self, ast_node):
-        """Is the node a paragraph?"""
-        return ast_node.t == "Paragraph"
+    def get_doc_title(self):
+        """Get the document title of the document."""
+        return self._get_info_from_header("title")
 
-    def is_list(self, ast_node):
-        """Is the node a list? (ordered or unordered)"""
-        return ast_node.t == "List"
+    def get_doc_subtitle(self):
+        """Get the document subtitle of the document."""
+        return self._get_info_from_header("subtitle")
 
-    def is_link(self, ast_node):
-        """Is the node a link?"""
-        return ast_node.t == "Link"
+    def get_headings(self):
+        """Returns a list of (level, title) of sections"""
+        headings = []
+        for ast_node in self.body:
+            if ast_node["t"] == "Header":
+                headings.append((ast_node["c"][0],
+                                 ast_to_string(ast_node["c"][2])))
 
-    def is_external(self, ast_node):
-        """Does the node reference content outside the file? (image or link)"""
-        return ast_node.t in ("Link", "Image")
+        return headings
 
-    def is_block(self, ast_node):
-        """Is the node a BlockQuoted element?"""
-        return ast_node.t == "BlockQuote"
+    def get_boxes(self):
+        boxes = []
 
-    def is_callout(self, ast_node):
-        """Composite element: "callout" elements in SWC templates are
-        blockquotes whose first child element is a heading"""
-        if len(ast_node.children) > 0 and \
-                self.is_heading(ast_node.children[0]):
-            has_heading = True
-        else:
-            has_heading = False
+        for ast_node in self.body:
+            if is_box(ast_node):
+                boxes.append(ast_node)
 
-        return self.is_block(ast_node) and has_heading
+        return boxes


### PR DESCRIPTION
I changed `tools/check.py` to use Pandoc trying to keep all Pandoc AST stuffs at `tools/validation_helpers.py`. I also updated `tools/test_check.py`.

**Warnings**:
- Some validations were removed since they are handle by Pandoc.
- Some tests were removed since they no longer make sense.
- Integration tests were removed. We are going to keep the integration tests at `gh-pages` branch.

@abought Could we merge this as soon as possible and fix things later?
