### PR TITLE
Load bootstrap from CDN

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,11 +72,12 @@ this template is organized the way it is:
     our generated files in a different directory, the paths won't work
     there).
 
-7.  In order to display properly, our generated HTML pages need
-    artwork, CSS style files, and a few bits of Javascript.  We could
-    load these from the web, but that would make offline authoring
-    difficult.  Instead, each lesson's repository has a copy of these
-    files, and a way of updating them (and only them) on demand.
+7.  In order to display properly, our generated HTML pages need artwork,
+    CSS style files, and a few bits of Javascript.  We could load these
+    from the web e.g. from a content delivery network (CDN), but that
+    would make offline authoring difficult.  Instead, each lesson's
+    repository is self-contained and has a copy of all these third party
+    resources, and a way of updating them (and only them) on demand.
 
 One final note: we try not to put HTML inside Markdown because it's
 ugly to read and write, and error-prone to process. Instead, we put


### PR DESCRIPTION
The simplest way to include bootstrap these days is to [load it from CDN](http://getbootstrap.com/getting-started/#download-cdn). It also keeps the repo size down and the working tree slim.

How important is it for the lessons to work offline? See also #121 on the use of MathJax, which is a _very heavy_ dependency when not loaded from CDN.
