### PR TITLE
Fix link to git pro book

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ you are agreeing that Software Carpentry may redistribute your work under
 
 [lesson-template-issues]: https://github.com/swcarpentry/lesson-template/issues
 [license]: LICENSE.md
-[pro-git]: http://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project
+[pro-git-chapter]: http://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project
 [swc-lessons]: http://software-carpentry.org/lessons.html
 [swc-maintainers]: http://software-carpentry.org/lessons.html#maintainers
 [swc-website]: http://software-carpentry.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ you are agreeing that Software Carpentry may redistribute your work under
 
 [lesson-template-issues]: https://github.com/swcarpentry/lesson-template/issues
 [license]: LICENSE.md
-[pro-git]: http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
+[pro-git]: http://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project
 [swc-lessons]: http://software-carpentry.org/lessons.html
 [swc-maintainers]: http://software-carpentry.org/lessons.html#maintainers
 [swc-website]: http://software-carpentry.org


### PR DESCRIPTION
The link to Chacon's book was broken. This fixes it.
