### PR TITLE
Fixes to lesson layout instructions

### DIFF
--- a/LAYOUT.md
+++ b/LAYOUT.md
@@ -4,15 +4,15 @@ Each lesson is stored in a directory laid out as described below. That
 directory is a self-contained Git repository (i.e., there are no
 submodules or clever tricks with symbolic links).
 
-1.  `README.md`: initially a copy of this file.  It should be
+1.  `README.md`: initially a copy of this repository's README file.  It should be
     overwritten with short description of the lesson, but should
     include the following blockquote to help people find these
     instructions:
 
     ~~~
-    > Please see [https://github.com/swcarpentry/lesson-template](https://github.com/swcarpentry/lesson-template)
-    > for instructions on formatting, building, and submitting lessons,
-    > or run `make` in this directory for a list of helpful commands.
+    Please see [https://github.com/swcarpentry/lesson-template](https://github.com/swcarpentry/lesson-template)
+    for instructions on formatting, building, and submitting lessons,
+    or run `make` in this directory for a list of helpful commands.
     ~~~
 
 2.  Other files in the root directory: the source of the lesson's web

--- a/LAYOUT.md
+++ b/LAYOUT.md
@@ -10,9 +10,9 @@ submodules or clever tricks with symbolic links).
     instructions:
 
     ~~~
-    Please see [https://github.com/swcarpentry/lesson-template](https://github.com/swcarpentry/lesson-template)
-    for instructions on formatting, building, and submitting lessons,
-    or run `make` in this directory for a list of helpful commands.
+    > Please see [https://github.com/swcarpentry/lesson-template](https://github.com/swcarpentry/lesson-template)
+    > for instructions on formatting, building, and submitting lessons,
+    > or run `make` in this directory for a list of helpful commands.
     ~~~
 
 2.  Other files in the root directory: the source of the lesson's web


### PR DESCRIPTION
Changed the reference to the lesson's README file -- it's not "this file" any more (this file is LAYOUT.md). 

Also removed the ">"s from the beginning of the block of text to be included in the README, to enable copying-and-pasting (and because the ~~~ should offset the quote by itself. I hope.
