### PR TITLE
Validator should ignore CONDUCT.md and CONTRIBUTING.md

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -671,7 +671,8 @@ LESSON_TEMPLATES = {"index": (IndexPageValidator, "^index"),
                     "discussion": (DiscussionPageValidator, "^discussion")}
 
 # List of files in the lesson directory that should not be validated at all
-SKIP_FILES = ("DESIGN.md", "FAQ.md", "LAYOUT.md", "README.md")
+SKIP_FILES = ("CONDUCT.md", "CONTRIBUTING.md",
+              "DESIGN.md", "FAQ.md", "LAYOUT.md", "README.md")
 
 
 def identify_template(filepath):


### PR DESCRIPTION
Per @gvwilson email, validator should ignore two files that appear in every lesson. (CONDUCT.md and CONTRIBUTING.md)

Confirmed that validator passes all tests, in python 2 and 3.
