### PR TITLE
AUTHORS: List contributors to this project

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Andy Boughton <abought@gmail.com> <pchemist@gmail.com>
+Greg Wilson <gvwilson@software-carpentry.org> <gvwilson@third-bit.com>

--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -1,0 +1,17 @@
+[project]
+name: lesson-template
+vcs: Git
+
+[files]
+authors: yes
+files: no
+
+[copyright]
+short: {project} comes with ABSOLUTELY NO WARRANTY and is licensed under the MIT and CC BY 4.0 licenses.
+long: This file is part of {project}.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,12 @@
+lesson-template was written by:
+Aaron O'Leary <aaron.oleary@gmail.com>
+Andy Boughton <abought@gmail.com>
+Bill Mills <mills.wj@gmail.com>
+Greg Wilson <gvwilson@software-carpentry.org>
+James Allen <jamesallen0108@gmail.com>
+John Blischak <jdblischak@gmail.com>
+Raniere Silva <raniere@ime.unicamp.br>
+Rémi Emonet <remi.emonet@reverse--com.heeere>
+Timothée Poisot <tim@poisotlab.io>
+Trevor Bekolay <tbekolay@gmail.com>
+W. Trevor King <wking@tremily.us>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 CommonMark
 pandocfilters
 PyYAML
+update-copyright

--- a/tools/check.py
+++ b/tools/check.py
@@ -671,7 +671,8 @@ LESSON_TEMPLATES = {"index": (IndexPageValidator, "^index"),
                     "discussion": (DiscussionPageValidator, "^discussion")}
 
 # List of files in the lesson directory that should not be validated at all
-SKIP_FILES = ("DESIGN.md", "FAQ.md", "LAYOUT.md", "README.md")
+SKIP_FILES = ("CONDUCT.md", "CONTRIBUTING.md",
+              "DESIGN.md", "FAQ.md", "LAYOUT.md", "README.md")
 
 
 def identify_template(filepath):


### PR DESCRIPTION
Spun off from #195.

Give credit for folks who have authored commits in this project.  To
list non-committing contributors (e.g. prolific bug reporters or
triagers), you can use something like:

  [author-hacks]
  AUTHORS: Alice Doe adoe@example.com |
    Bob Smith bsmith@example.com

After merging into gh-pages, you'll want to rerun update-copyright.py
to pull in the gh-pages-only contributors.  You may also need to
expand the .mailmap file with entries for that branch too.
