### PR TITLE
AUTHORS: List contributors to this project

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Andy Boughton <abought@gmail.com> <pchemist@gmail.com>
+Greg Wilson <gvwilson@software-carpentry.org> <gvwilson@third-bit.com>

--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -1,0 +1,6 @@
+[project]
+vcs: Git
+
+[files]
+authors: yes
+files: no

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,12 @@
+lesson-template was written by:
+Aaron O'Leary <aaron.oleary@gmail.com>
+Andy Boughton <abought@gmail.com>
+Bill Mills <mills.wj@gmail.com>
+Greg Wilson <gvwilson@software-carpentry.org>
+James Allen <jamesallen0108@gmail.com>
+John Blischak <jdblischak@gmail.com>
+Raniere Silva <raniere@ime.unicamp.br>
+Rémi Emonet <remi.emonet@reverse--com.heeere>
+Timothée Poisot <tim@poisotlab.io>
+Trevor Bekolay <tbekolay@gmail.com>
+W. Trevor King <wking@tremily.us>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 CommonMark
 pandocfilters
 PyYAML
+update-copyright


### PR DESCRIPTION
Spun off from #195.

Give credit for folks who have authored commits in this project. To
list non-committing contributors (e.g. prolific bug reporters or
triagers), you can use something like:

```
[author-hacks]
AUTHORS: Alice Doe adoe@example.com |
  Bob Smith bsmith@example.com
```

After merging into gh-pages, you'll want to rerun update-copyright.py
to pull in the gh-pages-only contributors. You may also need to
expand the .mailmap file with entries for that branch too.
