### PR TITLE
CONTRIBUTING.md: Use a generic reference name for the issues link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ You also agree to abide by our
 3.  When editing lesson pages, you need only commit changes to the Markdown source files.
 
 4.  If you're looking for things to work on,
-    please see [the list of issues for this repository][lesson-template-issues],
+    please see [the list of issues for this repository][issues],
     or for [our other lessons][swc-lessons].
     Comments on issues and reviews of pull requests are equally welcome.
 
@@ -41,7 +41,7 @@ You also agree to abide by our
     Feel free to contact them if you have any questions or languishing pull requests.
 
 [conduct]: CONDUCT.md
-[lesson-template-issues]: https://github.com/swcarpentry/lesson-template/issues
+[issues]: https://github.com/swcarpentry/lesson-template/issues
 [license]: LICENSE.md
 [pro-git-chapter]: http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
 [swc-lessons]: http://software-carpentry.org/lessons.html


### PR DESCRIPTION
Downstream lesson maintainers are [supposed to adapt this to point at
their repository's issues](https://github.com/swcarpentry/lesson-template/issues/195#issuecomment-78310923), so use a reference name that works for
both the lesson-template and downstream repositories.  That way they
only have to update the referenced URL and can leave the reference
name alone.

For an example of the currently-required double-edit, see
swcarpentry/sql-novice-survey#54.
