### PR TITLE
Add img-responsive class to img

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ motivation.html : motivation.md _layouts/slides.revealjs Makefile
 	--filter=tools/filters/id4glossary.py \
 	$(INCLUDES) \
 	-o $@ $<
+	sed -i 's/^<img /<img class="img-responsive" /g' $@
 
 # Pattern to convert R Markdown to Markdown.
 %.md: %.Rmd $(R_CHUNK_OPTS)


### PR DESCRIPTION
**Don't merge this pull request.** It is just a example.

Add `.img-responsive` class to images in our lessons. You can read more about `img-responsive` class at http://getbootstrap.com/css/#images-responsive.

For preview the HTML, check https://github.com/r-gaia-cs/swc-lesson-example/tree/example-centering-image.
