### PR TITLE
Remove logger name (root) from console messages

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -738,7 +738,9 @@ def validate_folder(path, template=None):
 
 def start_logging(level=logging.INFO):
     """Initialize logging and print messages to console."""
-    logging.basicConfig(stream=sys.stdout, level=level)
+    logging.basicConfig(stream=sys.stdout,
+                        level=level,
+                        format="%(levelname)s: %(message)s")
 
 
 def command_line():


### PR DESCRIPTION
As previously noted by @gvwilson , console messages from the validator currently contain the logger name (`root`), which is unnecessary and confusing.

`ERROR:root:Missing file 01-*.md.`

This is a small change that alters the log format string, so that messages now appear as follows:

`ERROR: Missing file 01-*.md.`

Reference on logging library format string options is here:
https://docs.python.org/2/library/logging.html#logrecord-attributes
