### PR TITLE
CONTRIBUTING.md: Remove the maintainer references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,15 +35,8 @@ You also agree to abide by our
 
 2.  For a list of helpful commands run `make` in this directory.
 
-3.  The [list of maintainers][swc-maintainers]
-    on the [Software Carpentry website][swc-website]
-    lists the people currently responsible for managing this repository.
-    Feel free to contact them if you have any questions or languishing pull requests.
-
 [conduct]: CONDUCT.md
 [issues]: https://github.com/swcarpentry/lesson-template/issues
 [license]: LICENSE.md
 [pro-git-chapter]: http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
 [swc-lessons]: http://software-carpentry.org/lessons.html
-[swc-maintainers]: http://software-carpentry.org/lessons.html#maintainers
-[swc-website]: http://software-carpentry.org


### PR DESCRIPTION
Because we're going to be storing maintainer information [locally in
the README.md](https://github.com/swcarpentry/lesson-template/issues/195#issuecomment-89643048).
