### PR TITLE
Exclude LICENSE.md from html translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DST_RMD = $(patsubst %.Rmd,%.md,$(SRC_RMD))
 
 # All Markdown files (hand-written and generated).
 ALL_MD = $(wildcard *.md) $(DST_RMD)
-EXCLUDE_MD = README.md LAYOUT.md FAQ.md DESIGN.md CONTRIBUTING.md CONDUCT.md
+EXCLUDE_MD = README.md LICENSE.md LAYOUT.md FAQ.md DESIGN.md CONTRIBUTING.md CONDUCT.md
 SRC_MD = $(filter-out $(EXCLUDE_MD),$(ALL_MD))
 DST_HTML = $(patsubst %.md,%.html,$(SRC_MD))
 


### PR DESCRIPTION
Do not create LICENSE.html with `make preview`
