### PR TITLE
Add client-side hooks for lesson maintainers to regenerate HTML

### DIFF
--- a/tools/maintainer_hooks/README.md
+++ b/tools/maintainer_hooks/README.md
@@ -1,0 +1,32 @@
+This directory contains client-side hooks that lesson maintainers can
+use to regenerate HTML files and update zip files if necessary.
+
+With this hook enabled, lesson maintainers will no longer have to update
+the lesson data zip file or execute `make preview` to regenerate HTML.
+This will be done automatically as part of the post-commit hook.
+
+If you want to commit only the regenerated HTML and/or the updated zip file, 
+There are two options:
+
+1. Regenerate HTML or update the zip file manually, just as you would
+without the hooks. The post-commit `make preview` and the `zip` commands
+won't update a file that's already up-to-date.
+2. Submit an empty commit using `git commit --allow-empty`. Remember
+to use a descriptive commit message even though you are using an
+"empty" commit. After your commit, the post-commit script will add the
+regenerated HTML and/or updated zip file.
+
+To use the hooks, first edit the parameters `ZIP_FILE` and `DATA_DIR`
+in the `post-commit` script. Then create symlinks in the `.git/hooks`
+directory by executing the following commands from anywhere within the
+project's file tree
+
+```bash
+# Go to the .git/hooks directory.
+cd "$(git rev-parse --show-toplevel)"/.git/hooks
+# Create symlinks.
+ln -s -f ../../tools/maintainer_hooks/pre-commit pre-commit
+ln -s -f ../../tools/maintainer_hooks/post-commit post-commit
+# Go back to where you were.
+cd -
+```

--- a/tools/maintainer_hooks/post-commit
+++ b/tools/maintainer_hooks/post-commit
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# If hidden file .commit exists, then we know that a commit just
+# happened but the post-commit hook hasn't executed yet. Use this fact
+# to regenerate HTML files, add them, and amend the last commit.
+#
+# To enable this hook, create a symlink to it in the .git/hooks
+# directory by executing the following commands from anywhere within the 
+# project file tree:
+# # Go to the .git/hooks directory.
+# $ cd "$(git rev-parse --show-toplevel)"/.git/hooks
+# # Create symlink.
+# $ ln -s -f ../../tools/maintainer_hooks/post-commit post-commit
+# # Go back to where you were.
+# $ cd -
+
+# Lesson maintainers, edit these parameters to fit your lesson.
+# e.g. for python-novice-inflammation
+# ZIP_FILE=python-novice-inflammation-data.zip
+# DATA_DIR=data
+ZIP_FILE=insert_zip_file_name_here.zip
+DATA_DIR=data
+
+if [ -f .commit ]
+    then
+    rm -f .commit
+    # If $DATA_DIR exists, then make sure the zipfile is up to date.
+    [ -d "$DATA_DIR" ] && zip --filesync --recurse-paths "$ZIP_FILE" "$DATA_DIR"
+    make preview
+    git add -u *.html
+    git add -u "$ZIP_FILE"
+    # Amend previous commit using same message
+    # Use --no-verify to bypass pre-commit hook
+    # so that we avoid getting caught in a loop
+    git commit --amend -C HEAD --no-verify
+fi

--- a/tools/maintainer_hooks/pre-commit
+++ b/tools/maintainer_hooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Create hidden file .commit to signal to the post-commit hook that it
+# should re-zip the data folder if necessary and regenerate the HTML.
+# Called by "git commit" with no arguments.
+#
+# To enable this hook, create a symlink to it in the .git/hooks
+# directory by executing the following commands from anywhere within the
+# project file tree:
+# # Go to the .git/hooks directory.
+# $ cd "$(git rev-parse --show-toplevel)"/.git/hooks
+# # Create symlink.
+# $ ln -s -f ../../tools/maintainer_hooks/pre-commit pre-commit
+# # Go back to where you were.
+# $ cd -
+
+touch .commit


### PR DESCRIPTION
and update zip files.

This enhancement grew out of [issue 94](https://github.com/swcarpentry/python-novice-inflammation/issues/94) in the python-novice-inflammation repository and the discussion in a [shell-novice PR](https://github.com/swcarpentry/shell-novice/pull/141).

It creates a maintainer_hooks directory in the tools directory. Lesson maintainers can use these hooks by symlinking to them in the .git/hooks directory. The pre-commit hook sets a "flag" file called .commit and the post-commit hook detects the presence of this flag and regenerates HTML and updates the data zip file if necessary. It then amends the previous commit by adding these files to the commit and keeping the same message.

Thanks to @tbekolay and @iglpdc for feedback.
