### PR TITLE
Adding simple tool to extract challenges from Markdown files

### DIFF
--- a/tools/extract_challenges.py
+++ b/tools/extract_challenges.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+'''Extract challenges from lessons.'''
+
+import sys
+import re
+
+
+USAGE = 'usage: extract_challenges [-o output_name] [filename...]'
+
+title_pat = re.compile(r'^>\s+.+\{.challenge\}')
+block_pat = re.compile(r'^>')
+
+def main(argv):
+    '''Main driver.'''
+
+    prog_name = argv[0]
+    filenames = argv[1:]
+    output_name = None
+    writer = sys.stdout
+
+    if filenames and (filenames[0] == '-o'):
+        if len(filenames) < 2:
+            fail(USAGE)
+        output_name = filenames[1]
+        filenames = filenames[2:]
+
+    if output_name:
+        writer = open(output_name, 'w')
+
+    if filenames:
+        for f in filenames:
+            with open(f, 'r') as reader:
+                extract(reader, sys.stdout)
+    else:
+        extract(sys.stdin, sys.stdout)
+
+    if writer != sys.stdout:
+        writer.close()
+
+
+def extract(reader, writer):
+    '''Extract challenges from reader, sending to writer.'''
+
+    echo = False
+    for line in reader:
+        if title_pat.search(line):
+            echo = True
+        if echo and (not block_pat.search(line)):
+            print >> writer
+            echo = False
+        if echo:
+            print >> writer, line.rstrip()
+    print >> writer
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/tools/extract_challenges.py
+++ b/tools/extract_challenges.py
@@ -21,7 +21,8 @@ def main(argv):
 
     if filenames and (filenames[0] == '-o'):
         if len(filenames) < 2:
-            fail(USAGE)
+            print >> sys.stderr, USAGE
+            sys.exit(1)
         output_name = filenames[1]
         filenames = filenames[2:]
 
@@ -31,9 +32,9 @@ def main(argv):
     if filenames:
         for f in filenames:
             with open(f, 'r') as reader:
-                extract(reader, sys.stdout)
+                extract(reader, writer)
     else:
-        extract(sys.stdin, sys.stdout)
+        extract(sys.stdin, writer)
 
     if writer != sys.stdout:
         writer.close()


### PR DESCRIPTION
This adds a simple Python script to extract challenges from Markdown files.  Once the script passes muster, we'll add a target to the Makefile to drive it.  This is to close #120.
