### PR TITLE
Removed lingering references to motivation.md and motivation.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,6 @@ clean :
 ## preview  : Build website locally for checking.
 preview : $(DST_ALL)
 
-# Pattern for slides (different parameters and template).
-motivation.html : motivation.md _layouts/slides.revealjs Makefile
-	${PANDOC} -s -t revealjs --slide-level 2 \
-	    ${PANDOC_FLAGS} \
-	    --template=_layouts/slides \
-	    -o $@ $<
-
 # Pattern to build a generic page.
 %.html : %.md _layouts/page.html $(FILTERS)
 	${PANDOC} -s -t html \

--- a/tools/check.py
+++ b/tools/check.py
@@ -542,16 +542,6 @@ class TopicPageValidator(MarkdownValidator):
         return all(tests) and parent_tests
 
 
-class MotivationPageValidator(MarkdownValidator):
-    """Validate motivation.md"""
-    WARN_ON_EXTRA_HEADINGS = False
-
-    DOC_HEADERS = {"layout": vh.is_str,
-                   "title": vh.is_str,
-                   "subtitle": vh.is_str}
-    # TODO: How to validate? May be a mix of reveal.js (HTML) + markdown.
-
-
 class ReferencePageValidator(MarkdownValidator):
     """Validate reference.md"""
     HEADINGS = ["Glossary"]
@@ -678,7 +668,6 @@ class DiscussionPageValidator(MarkdownValidator):
 #   Dict of {name: (Validator, filename_pattern)}
 LESSON_TEMPLATES = {"index": (IndexPageValidator, "^index"),
                     "topic": (TopicPageValidator, "^[0-9]{2}-.*"),
-                    "motivation": (MotivationPageValidator, "^motivation"),
                     "reference": (ReferencePageValidator, "^reference"),
                     "instructor": (InstructorPageValidator, "^instructors"),
                     "license": (LicensePageValidator, "^LICENSE"),
@@ -786,7 +775,6 @@ def check_required_files(dir_to_validate):
                       "index.md",
                       "instructors.md",
                       "LICENSE.md",
-                      "motivation.md",
                       "README.md",
                       "reference.md"]
     valid = True

--- a/tools/test_check.py
+++ b/tools/test_check.py
@@ -99,7 +99,6 @@ This will parse as a string, not a dictionary
 
 ## Other Resources
 
-*   [Motivation](motivation.html)
 *   [Reference Guide](reference.html)
 *   [Next Steps](discussion.html)
 *   [Instructor's Guide](instructors.html)""")
@@ -114,7 +113,6 @@ This will parse as a string, not a dictionary
 
 ## Other Resources
 
-*   [Motivation](motivation.html)
 *   [Reference Guide](reference.html)
 *   [Next Steps](discussion.html)
 *   [Instructor's Guide](instructors.html)""")
@@ -141,7 +139,6 @@ Paragraph of introductory material.
 
 ## Other Resources
 
-*   [Motivation](motivation.html)
 *   [Reference Guide](reference.html)
 *   [Next Steps](discussion.html)
 *   [Instructor's Guide](instructors.html)""")
@@ -161,7 +158,6 @@ Paragraph of introductory material.
 
 ## Other Resources
 
-* [Motivation](motivation.html)
 * [Reference Guide](reference.html)
 * [Instructor's Guide](instructors.html)
 
@@ -437,17 +433,6 @@ Spacer paragraph
 >
 > Further exposition""")
         self.assertTrue(validator._validate_callouts())
-
-    def test_sample_file_passes_validation(self):
-        sample_validator = self.VALIDATOR(self.SAMPLE_FILE)
-        res = sample_validator.validate()
-        self.assertTrue(res)
-
-
-class TestMotivationPage(BaseTemplateTest):
-    """Verifies that the instructors page validator works as expected"""
-    SAMPLE_FILE = os.path.join(MARKDOWN_DIR, "motivation.md")
-    VALIDATOR = check.MotivationPageValidator
 
     def test_sample_file_passes_validation(self):
         sample_validator = self.VALIDATOR(self.SAMPLE_FILE)


### PR DESCRIPTION
When writing a new lesson, running `make check` gave:

```
$ make check
python tools/check.py .
ERROR: Missing file motivation.md.
WARNING: 1 errors were encountered during validation. See log for details.
make: *** [check] Error 1
```

Adding motivation.md gave:

```
$ make preview
...
make: *** No rule to make target `_layouts/slides.revealjs', needed by `motivation.html'.  Stop.
```

This file does not exist and was removed as part of https://github.com/swcarpentry/lesson-template/pull/273. From that pull request, and https://github.com/swcarpentry/lesson-template/issues/264, which comments:

> Move the motivation slides to the slideshows repo, but keep the content (in prose form) at the 
> start of instructors.md to show new instructors how to motivate a lesson.

the lingering mentions of motivation.html and motivation.md should be removed also? This pull request  does that.
