### PR TITLE
Add support for error class for R Markdown generated lessons

### DIFF
--- a/tools/chunk-options.R
+++ b/tools/chunk-options.R
@@ -9,7 +9,7 @@ opts_chunk$set(tidy = FALSE, results = "markup", comment = NA,
                fig.align = "center", fig.path = "fig/")
 
 # The hooks below add html tags to the code chunks and their output so that they
-# are properly formatted when the site is built with jekyll.
+# are properly formatted when the site is built.
 hook_in <- function(x, options) {
   stringr::str_c("\n\n~~~{.r}\n",
                  paste0(x, collapse="\n"),
@@ -22,5 +22,11 @@ hook_out <- function(x, options) {
                  "\n~~~\n\n")
 }
 
-knit_hooks$set(source = hook_in, output = hook_out, warning = hook_out,
-               error = hook_out, message = hook_out)
+hook_error <- function(x, options) {
+  stringr::str_c("\n\n~~~{.error}\n",
+                 paste0(x, collapse="\n"),
+                 "\n~~~\n\n")
+}
+
+knit_hooks$set(source = hook_in, output = hook_out, warning = hook_error,
+               error = hook_error, message = hook_out)


### PR DESCRIPTION
The lesson template has three options for the [formatting of code blocks](https://github.com/swcarpentry/lesson-example/blob/gh-pages/LAYOUT.md#topics):
- input - green text
- output - blue text
- error - red text

Currently the output of R Markdown chunks is always displayed in blue text. This PR updates this so that errors and warnings appear in red text. I kept messages as blue text, but do not have strong feelings as to whether messages are displayed in blue or red font. Please let me know if you have an opinion on how messages should be displayed.
