### PR TITLE
Accommodate CommonMark's renaming of DocParser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-CommonMark
+CommonMark==0.5.5
 pandocfilters
 PyYAML
 update-copyright

--- a/tools/check.py
+++ b/tools/check.py
@@ -84,7 +84,7 @@ class MarkdownValidator(object):
         self._callout_counts = collections.Counter()
 
     def _parse_markdown(self, markdown):
-        parser = CommonMark.DocParser()
+        parser = CommonMark.Parser()
         ast = parser.parse(markdown)
         return ast
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -84,7 +84,7 @@ class MarkdownValidator(object):
         self._callout_counts = collections.Counter()
 
     def _parse_markdown(self, markdown):
-        parser = CommonMark.Parser()
+        parser = CommonMark.DocParser()
         ast = parser.parse(markdown)
         return ast
 


### PR DESCRIPTION
`make check` currently fails due to an `AttributeError: 'module' object has no attribute 'DocParser'`.

It looks like `CommonMark.DocParser` was [renamed](https://github.com/rtfd/CommonMark-py/blob/master/CHANGELOG.md#060-2016-01-04) to `CommonMark.Parser` about a month ago. A simple rename makes it work for me.
### Update: See my comments below.
