### PR TITLE
Prevents inline code samples from wrapping.

### DIFF
--- a/css/swc-print.css
+++ b/css/swc-print.css
@@ -37,6 +37,11 @@
     background: unset;
   }
 
+  /* don't wrap code samples inlined in paragraphs */
+  p > code {
+  	white-space: nowrap;
+  }
+
   pre.sourceCode::before,
   pre.input::before. {
       content: "Input:";
@@ -71,4 +76,3 @@
     display: none;
   }
 }
-

--- a/css/swc.css
+++ b/css/swc.css
@@ -185,6 +185,11 @@ pre.error {
     color: Red;
 }
 
+/* don't wrap code samples inlined in paragraphs */
+p > code {
+	white-space: nowrap;
+}
+
 @media (max-width: 700px) {
     div.banner a img {
         padding: 20px 0px;


### PR DESCRIPTION
Resolves #296 -- Code samples within paragraphs (i.e. not blocks of code, but the markup delineating commands etc used in a normal English paragraph) would sometimes run up against the right margin and wrap, producing misleading results.

This adds a nowrap rule to the CSS, including the print stylesheet, in order to prevent line wrapping occurring inside a `<code>` tag, when the code tag is itself inside a `<p>`aragraph tag.

I can't easily get the pandoc workflow to happen on my machine (perhaps because this is just a template repo), so my testing of this has been limited to dynamically insert the CSS rule into lesson pages in-browser, and check the result.
