### PR TITLE
Adding callouts as allowable to more page types

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -622,6 +622,8 @@ class InstructorPageValidator(MarkdownValidator):
     DOC_HEADERS = {"layout": vh.is_str,
                    "title": vh.is_str,
                    "subtitle": vh.is_str}
+    CALLOUTS = {"callout": (None, 0, None),
+                "challenge": (None, 0, None)}
 
     def _partition_links(self):
         """For instructors.md, only check that text of link matches
@@ -662,6 +664,8 @@ class DiscussionPageValidator(MarkdownValidator):
     DOC_HEADERS = {"layout": vh.is_str,
                    "title": vh.is_str,
                    "subtitle": vh.is_str}
+    CALLOUTS = {"callout": (None, 0, None),
+                "challenge": (None, 0, None)}
 
 
 # Associate lesson template names with validators. This list used by CLI.


### PR DESCRIPTION
This change adds the callouts for the {.callout} and {.challenge} types to the instructors.md and the discussion.md pages, suppressing these errors when they are used there.

```
$ make check
python tools/check.py .
ERROR: In ./discussion.md: Found callout box with unrecognized style 'callout'
ERROR: In ./instructors.md: Found callout box with unrecognized style 'challenge'
WARNING: 2 errors were encountered during validation. See log for details.
make: *** [check] Error 2
```

I don't think there are any unintended consequences from doing this.
